### PR TITLE
feat(library v0.8.0): auto-add prometheus.io/scrape annotations + pod…

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/deployment.yaml
+++ b/library-chart/templates/deployment.yaml
@@ -13,6 +13,17 @@ spec:
     metadata:
       labels:
         {{- include "suse-library.selectorLabels" . | nindent 8 }}
+      {{- if or .Values.metrics.enabled .Values.podAnnotations }}
+      annotations:
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: {{ .Values.metrics.path | quote }}
+        prometheus.io/port: {{ .Values.metrics.port | default .Values.port | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/library-chart/values.yaml
+++ b/library-chart/values.yaml
@@ -30,6 +30,26 @@ probes:
   liveness:  {path: /health, initialDelaySeconds: 10, periodSeconds: 10}
   readiness: {path: /ready,  initialDelaySeconds: 5,  periodSeconds: 5}
 
+# ─── Prometheus scrape annotations (opinionated default) ───
+# When metrics.enabled is true, the app pod is annotated with
+#   prometheus.io/scrape: "true"
+#   prometheus.io/path:   <metrics.path>      (default /metrics)
+#   prometheus.io/port:   <metrics.port>      (default .Values.port)
+# so the Prometheus chart's `kubernetes-pods` discovery picks it up
+# automatically without any extra ServiceMonitor / PodMonitor config.
+# Disable when your app does not expose a /metrics endpoint.
+metrics:
+  enabled: true
+  path: /metrics
+  # port: 8080  # defaults to .Values.port
+
+# Free-form pod annotations merged into the Deployment's pod template.
+# Use for app-specific concerns (Linkerd inject, Istio sidecar config,
+# ingress-nginx auth annotations propagated to pods, etc.). Prometheus
+# scrape annotations live in the metrics block above; setting the same
+# keys here will override them.
+podAnnotations: {}
+
 # ─────────────────────────────────────────────────────────────────────
 # CATALOGUE: AppCo charts the project can opt into
 # ─────────────────────────────────────────────────────────────────────

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.7.0
+  version: 0.8.0
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.7.0
+    version: 0.8.0
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in

--- a/templates/web-nodejs/chart/charts/suse-library/Chart.yaml
+++ b/templates/web-nodejs/chart/charts/suse-library/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/templates/web-nodejs/chart/charts/suse-library/templates/deployment.yaml
+++ b/templates/web-nodejs/chart/charts/suse-library/templates/deployment.yaml
@@ -13,6 +13,17 @@ spec:
     metadata:
       labels:
         {{- include "suse-library.selectorLabels" . | nindent 8 }}
+      {{- if or .Values.metrics.enabled .Values.podAnnotations }}
+      annotations:
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: {{ .Values.metrics.path | quote }}
+        prometheus.io/port: {{ .Values.metrics.port | default .Values.port | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/web-nodejs/chart/charts/suse-library/values.yaml
+++ b/templates/web-nodejs/chart/charts/suse-library/values.yaml
@@ -30,6 +30,26 @@ probes:
   liveness:  {path: /health, initialDelaySeconds: 10, periodSeconds: 10}
   readiness: {path: /ready,  initialDelaySeconds: 5,  periodSeconds: 5}
 
+# ─── Prometheus scrape annotations (opinionated default) ───
+# When metrics.enabled is true, the app pod is annotated with
+#   prometheus.io/scrape: "true"
+#   prometheus.io/path:   <metrics.path>      (default /metrics)
+#   prometheus.io/port:   <metrics.port>      (default .Values.port)
+# so the Prometheus chart's `kubernetes-pods` discovery picks it up
+# automatically without any extra ServiceMonitor / PodMonitor config.
+# Disable when your app does not expose a /metrics endpoint.
+metrics:
+  enabled: true
+  path: /metrics
+  # port: 8080  # defaults to .Values.port
+
+# Free-form pod annotations merged into the Deployment's pod template.
+# Use for app-specific concerns (Linkerd inject, Istio sidecar config,
+# ingress-nginx auth annotations propagated to pods, etc.). Prometheus
+# scrape annotations live in the metrics block above; setting the same
+# keys here will override them.
+podAnnotations: {}
+
 # ─────────────────────────────────────────────────────────────────────
 # CATALOGUE: AppCo charts the project can opt into
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
…Annotations support

The library chart's deployment template now annotates the app pod with prometheus.io/scrape, prometheus.io/path, prometheus.io/port when metrics.enabled is true (default). Prometheus's kubernetes-pods discovery picks up the pod automatically — no ServiceMonitor or PodMonitor required.

New library values:
  metrics.enabled: true       # auto-add prom scrape annotations
  metrics.path:    /metrics
  metrics.port:    null       # defaults to .Values.port

  podAnnotations: {}          # free-form annotations merged into the
                              # pod template (Linkerd inject, Istio
                              # sidecar config, etc.)

Bumped:
  - library-chart Chart.yaml: 0.7.0 -> 0.8.0
  - rda-bundle.yaml library_chart.version: 0.7.0 -> 0.8.0
  - templates/web-nodejs/chart/Chart.yaml dep version: 0.7.0 -> 0.8.0
  - re-vendored templates/web-nodejs/chart/charts/suse-library/

After 'rda upgrade' on a project, the next 'tilt up' will surface the app's /metrics endpoint to Prometheus automatically.