### PR TITLE
feat(library v0.9.0): add Ingress template

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.8.0
+version: 0.9.0
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/ingress.yaml
+++ b/library-chart/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "suse-library.name" . }}
+  labels:
+    {{- include "suse-library.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $.Values.ingress.path | default "/" }}
+            pathType: {{ $.Values.ingress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "suse-library.name" $ }}
+                port:
+                  name: http
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/library-chart/values.yaml
+++ b/library-chart/values.yaml
@@ -50,6 +50,21 @@ metrics:
 # keys here will override them.
 podAnnotations: {}
 
+# ─── Ingress (optional) ───
+# When enabled, the library chart emits a single Ingress fronting the
+# application Service. Path rules are simple by default — one path per
+# host, all routed to the app's `http` port. Override `path`/`pathType`
+# for a different routing convention; use `annotations` to plug into
+# Traefik/nginx-specific behaviour (auth, rewrites, rate limits).
+ingress:
+  enabled: false
+  ingressClassName: ""        # e.g. "traefik" on Rancher Desktop, "nginx" elsewhere
+  hosts: []                   # e.g. - demo.localhost
+  path: /
+  pathType: Prefix
+  annotations: {}
+  tls: []                     # e.g. - {hosts: [demo.example.com], secretName: demo-tls}
+
 # ─────────────────────────────────────────────────────────────────────
 # CATALOGUE: AppCo charts the project can opt into
 # ─────────────────────────────────────────────────────────────────────

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.8.0
+  version: 0.9.0
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.8.0
+    version: 0.9.0
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in

--- a/templates/web-nodejs/chart/charts/suse-library/Chart.yaml
+++ b/templates/web-nodejs/chart/charts/suse-library/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.8.0
+version: 0.9.0
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/templates/web-nodejs/chart/charts/suse-library/templates/ingress.yaml
+++ b/templates/web-nodejs/chart/charts/suse-library/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "suse-library.name" . }}
+  labels:
+    {{- include "suse-library.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $.Values.ingress.path | default "/" }}
+            pathType: {{ $.Values.ingress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "suse-library.name" $ }}
+                port:
+                  name: http
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/templates/web-nodejs/chart/charts/suse-library/values.yaml
+++ b/templates/web-nodejs/chart/charts/suse-library/values.yaml
@@ -50,6 +50,21 @@ metrics:
 # keys here will override them.
 podAnnotations: {}
 
+# ─── Ingress (optional) ───
+# When enabled, the library chart emits a single Ingress fronting the
+# application Service. Path rules are simple by default — one path per
+# host, all routed to the app's `http` port. Override `path`/`pathType`
+# for a different routing convention; use `annotations` to plug into
+# Traefik/nginx-specific behaviour (auth, rewrites, rate limits).
+ingress:
+  enabled: false
+  ingressClassName: ""        # e.g. "traefik" on Rancher Desktop, "nginx" elsewhere
+  hosts: []                   # e.g. - demo.localhost
+  path: /
+  pathType: Prefix
+  annotations: {}
+  tls: []                     # e.g. - {hosts: [demo.example.com], secretName: demo-tls}
+
 # ─────────────────────────────────────────────────────────────────────
 # CATALOGUE: AppCo charts the project can opt into
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The library chart didn't have an Ingress template, so projects setting suse-library.ingress.enabled: true got their values silently ignored and no Ingress object was emitted.

New template at library-chart/templates/ingress.yaml. Renders one Ingress per project, fronting the application Service. One path per host, all routed to the app's http port (the Service's named port).

New library values:
  ingress:
    enabled: false
    ingressClassName: ""        # e.g. traefik on Rancher Desktop, nginx elsewhere
    hosts: []                  # e.g. - demo.localhost
    path: /
    pathType: Prefix
    annotations: {}            # plug into Traefik/nginx-specific behaviour
    tls: []                    # standard Ingress tls block

Bumped:
  - library-chart Chart.yaml: 0.8.0 -> 0.9.0
  - rda-bundle.yaml library_chart.version: 0.8.0 -> 0.9.0
  - templates/web-nodejs/chart/Chart.yaml dep version: 0.8.0 -> 0.9.0
  - re-vendored templates/web-nodejs/chart/charts/suse-library/

After 'rda upgrade' on a project, set suse-library.ingress.enabled: true in chart/values.yaml to expose the app behind the cluster's ingress controller.