### PR TITLE
feat(library v0.10.0): unified DSL services[] with helpers (Phase 1)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/_helpers.tpl
+++ b/library-chart/templates/_helpers.tpl
@@ -23,3 +23,160 @@ revisions (otherwise existing Deployments cannot find their Pods).
 app.kubernetes.io/name: {{ include "suse-library.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+DSL helpers — added in v0.10 for the unified `services[]` block.
+
+The DSL coexists with the legacy <chart>.* blocks (Phase 1, see PROPOSAL).
+Library templates consume the DSL for binding-secret rendering, app env
+projection, and audit labels. The legacy blocks still feed the AppCo
+sub-charts via Helm's standard sub-chart values resolution.
+
+`suse-library.dsl.services` returns the project's services[] list, or
+an empty list when not declared.
+*/}}
+{{- define "suse-library.dsl.services" -}}
+{{- if .Values.services -}}
+{{- toYaml .Values.services -}}
+{{- else -}}
+[]
+{{- end -}}
+{{- end -}}
+
+{{/*
+`suse-library.dsl.findByType` returns the FIRST service of a given type, or
+nothing if none. Use as: {{- $svc := include "suse-library.dsl.findByType"
+(dict "type" "postgresql" "Values" .Values) | fromYaml -}}.
+*/}}
+{{- define "suse-library.dsl.findByType" -}}
+{{- $type := .type -}}
+{{- range $i, $svc := .Values.services -}}
+{{- if eq $svc.type $type -}}
+{{- toYaml $svc -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+`suse-library.dsl.findByBinding` returns the FIRST service with a given
+binding name, or nothing if none.
+*/}}
+{{- define "suse-library.dsl.findByBinding" -}}
+{{- $binding := .binding -}}
+{{- range $i, $svc := .Values.services -}}
+{{- if eq $svc.binding $binding -}}
+{{- toYaml $svc -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+`suse-library.dsl.validateConsistency` fails loud if the DSL and the legacy
+<chart>.* blocks disagree on key fields (auth.user.password vs auth.password,
+etc.). Phase 1: the dev writes both; we ensure they don't drift.
+Phase 1.5: the rda CLI pre-processor will write the legacy blocks from the
+DSL, eliminating drift.
+*/}}
+{{- define "suse-library.dsl.validateConsistency" -}}
+{{- range $i, $svc := .Values.services -}}
+{{- $type := $svc.type -}}
+{{- $legacy := index $.Values $type | default dict -}}
+{{- if eq $type "postgresql" -}}
+{{- if and $legacy.enabled (and $svc.auth $svc.auth.user) -}}
+{{- if and $svc.auth.user.password $legacy.auth -}}
+{{- if and $legacy.auth.password (ne $svc.auth.user.password $legacy.auth.password) -}}
+{{- fail (printf "DSL drift: services[type=postgresql].auth.user.password (%s) != postgresql.auth.password (%s). Phase 1 requires the two views to agree until the rda CLI pre-processor lands. See rda-devx-catalog/PROPOSAL.md." $svc.auth.user.password $legacy.auth.password) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{/* Add similar checks for redis, grafana as those types land in services[] */}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+`suse-library.dsl.envFromBinding` projects the standard <BINDING>_* env
+vars referencing the binding-secret. Used in deployment.yaml for each
+service in services[]. Yields proper YAML at the env: list level.
+
+The shape is :
+  - { name: <BINDING>_HOST,     valueFrom: { secretKeyRef: { name: <release>-<binding>-binding, key: host     } } }
+  - { name: <BINDING>_PORT,     valueFrom: { secretKeyRef: { name: <release>-<binding>-binding, key: port     } } }
+  - { name: <BINDING>_USERNAME, valueFrom: { secretKeyRef: { name: <release>-<binding>-binding, key: username } } } (when present)
+  ...
+
+The set of projected keys per service type is documented in CATALOG.md.
+*/}}
+{{- define "suse-library.dsl.envFromBinding" -}}
+{{- $svc := .svc -}}
+{{- $release := .release -}}
+{{- $bindingUpper := upper $svc.binding | replace "-" "_" -}}
+{{- $secret := printf "%s-%s-binding" $release $svc.binding -}}
+- name: {{ $bindingUpper }}_HOST
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: host } }
+- name: {{ $bindingUpper }}_PORT
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: port } }
+{{- if eq $svc.type "postgresql" }}
+- name: {{ $bindingUpper }}_USERNAME
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: username } }
+- name: {{ $bindingUpper }}_PASSWORD
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: password } }
+- name: {{ $bindingUpper }}_DATABASE
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: database } }
+{{- else if eq $svc.type "redis" }}
+- name: {{ $bindingUpper }}_PASSWORD
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: password } }
+{{- else if eq $svc.type "grafana" }}
+- name: {{ $bindingUpper }}_URL
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: url } }
+- name: {{ $bindingUpper }}_ADMIN_USER
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: adminUser } }
+- name: {{ $bindingUpper }}_ADMIN_PASSWORD
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: adminPassword } }
+{{- end }}
+{{- end -}}
+
+{{/*
+`suse-library.dsl.bindingSecretFrom` renders a SBS binding-secret for a
+single DSL service entry. Used by binding-secret.yaml.
+*/}}
+{{- define "suse-library.dsl.bindingSecretFrom" -}}
+{{- $svc := .svc -}}
+{{- $root := .root -}}
+{{- $release := $root.Release.Name -}}
+{{- $name := printf "%s-%s-binding" $release $svc.binding }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "suse-library.labels" $root | nindent 4 }}
+    service.binding/binding-name: {{ $svc.binding }}
+    service.binding/binding-type: {{ $svc.type }}
+type: Opaque
+stringData:
+  type: {{ $svc.type | quote }}
+  provider: rda-appco
+{{- if eq $svc.type "postgresql" }}
+  host: "{{ $release }}-{{ $svc.type }}"
+  port: "5432"
+  username: {{ $svc.auth.user.name | default "app" | quote }}
+  password: {{ required (printf "services[binding=%s].auth.user.password is required for type=postgresql" $svc.binding) $svc.auth.user.password | quote }}
+  database: {{ required (printf "services[binding=%s].auth.user.database is required for type=postgresql" $svc.binding) $svc.auth.user.database | quote }}
+{{- else if eq $svc.type "redis" }}
+  host: "{{ $release }}-{{ $svc.type }}-master"
+  port: "6379"
+  password: {{ required (printf "services[binding=%s].auth.password is required for type=redis" $svc.binding) $svc.auth.password | quote }}
+{{- else if eq $svc.type "grafana" }}
+  host: "{{ $release }}-{{ $svc.type }}"
+  port: "80"
+  url: "http://{{ $release }}-{{ $svc.type }}"
+  adminUser: {{ $svc.auth.admin.name | default "admin" | quote }}
+  adminPassword: {{ required (printf "services[binding=%s].auth.admin.password is required for type=grafana" $svc.binding) $svc.auth.admin.password | quote }}
+{{- else }}
+{{- fail (printf "Unsupported service type %q for binding %q in DSL v1alpha1. Add a case to suse-library.dsl.bindingSecretFrom in _helpers.tpl. Supported in this version: postgresql, redis, grafana." $svc.type $svc.binding) }}
+{{- end }}
+{{- end -}}

--- a/library-chart/templates/binding-secret.yaml
+++ b/library-chart/templates/binding-secret.yaml
@@ -1,23 +1,38 @@
 {{/*
-  Service Binding Spec secrets, one per enabled AppCo service.
+  Service Binding Spec secrets.
 
-  Naming convention:
-    Secret      : <release>-<chart>-binding
-    SBS mount   : /bindings/<chart>/<key>
-    Host points : <release>-<chart>  (what the sub-chart actually deploys)
+  Two render paths in Phase 1 :
+    1. DSL path : when .Values.services is non-empty, render one
+       binding-secret per services[] entry, named <release>-<binding>-binding.
+       Helpers in _helpers.tpl handle per-type field shapes (postgresql,
+       redis, grafana, ...).
+    2. Legacy path : when .Values.services is empty, render the historical
+       <release>-<chart>-binding secrets, gated by .Values.<chart>.enabled.
+       Backward compatible with bundles <= v0.9.
 
-  Each Secret stays compatible with both:
-    - SBS apps reading /bindings/<chart>/<key> directly
-    - 12-factor apps reading env vars projected by deployment.yaml
-      using <CHART>_HOST/<CHART>_PORT/... naming, plus semantic
-      aliases (DB_HOST etc.) defined separately for portable libs.
+  Phase 1.5 (rda CLI pre-processor) will normalize: the DSL becomes the
+  single source of truth and the legacy blocks are auto-generated.
 
-  As we add more AppCo charts (mariadb, redis, milvus, ...), append a
-  new {{- if .Values.<chart>.enabled }} block below with that chart's
-  binding shape. Keep keys consistent across charts of the same
-  category (postgresql/mariadb/cloudnative-pg all expose
-  host/port/username/password/database).
+  Convention details :
+    Secret      : <release>-<binding>-binding (DSL) or <release>-<chart>-binding (legacy)
+    SBS mount   : /bindings/<binding>/<key> (in the app pod)
+    Host points : the AppCo sub-chart's deployed Service name
+    Keys        : type, provider, host, port, [username, password, database, url, adminUser, adminPassword]
 */}}
+
+{{- /* DSL consistency check first — fails loud on drift */ -}}
+{{- include "suse-library.dsl.validateConsistency" . -}}
+
+{{- if .Values.services -}}
+
+{{/* DSL path: render one binding-secret per services[] entry */}}
+{{- range $i, $svc := .Values.services }}
+{{- include "suse-library.dsl.bindingSecretFrom" (dict "svc" $svc "root" $) }}
+{{- end }}
+
+{{- else -}}
+
+{{/* Legacy path: gated by per-chart enabled flag */}}
 
 {{- if .Values.postgresql.enabled }}
 ---
@@ -54,11 +69,9 @@ type: Opaque
 stringData:
   type: prometheus
   provider: rda-appco
-  # AppCo Prometheus chart exposes its API on port 9090 via a
-  # ClusterIP service named <release>-prometheus-server.
   host: "{{ .Release.Name }}-prometheus-server"
-  port: "9090"
-  url: "http://{{ .Release.Name }}-prometheus-server:9090"
+  port: "80"
+  url: "http://{{ .Release.Name }}-prometheus-server"
 {{- end }}
 
 {{- if .Values.grafana.enabled }}
@@ -76,8 +89,10 @@ stringData:
   type: grafana
   provider: rda-appco
   host: "{{ .Release.Name }}-grafana"
-  port: "3000"
-  url: "http://{{ .Release.Name }}-grafana:3000"
-  adminUser: {{ required "grafana.adminUser is required when grafana.enabled=true" .Values.grafana.adminUser | quote }}
+  port: "80"
+  url: "http://{{ .Release.Name }}-grafana"
+  adminUser: {{ .Values.grafana.adminUser | default "admin" | quote }}
   adminPassword: {{ required "grafana.adminPassword is required when grafana.enabled=true" .Values.grafana.adminPassword | quote }}
 {{- end }}
+
+{{- end -}}

--- a/library-chart/templates/deployment.yaml
+++ b/library-chart/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
             - {name: SERVICE_BINDING_ROOT, value: /bindings}
             # 12-factor PORT — user code MUST respect process.env.PORT.
             - {name: PORT, value: "{{ .Values.port }}"}
+            {{- /* DSL path: project env from each services[] entry (Phase 1) */ -}}
+            {{- range $i, $svc := .Values.services }}
+            # ─── DSL binding {{ $svc.binding }} (type {{ $svc.type }}) ───
+            {{- include "suse-library.dsl.envFromBinding" (dict "svc" $svc "release" $.Release.Name) | nindent 12 }}
+            {{- end }}
             {{- if .Values.postgresql.enabled }}
             # ─── postgresql binding (12-factor projection) ───
             # Apps that prefer SBS read /bindings/postgresql/<key> instead.

--- a/library-chart/values.yaml
+++ b/library-chart/values.yaml
@@ -8,6 +8,23 @@ global:
   imagePullSecrets:
     - application-collection
 
+# ─── Unified DSL (apiVersion: rda.suse.com/v1alpha1) ───
+# When services[] is non-empty, the library renders binding-secrets and
+# env vars from this list (the DSL view). When empty, the library falls
+# back to the legacy <chart>.enabled gated path. See PROPOSAL.md in
+# rda-devx-catalog for the design rationale.
+#
+# Each service entry MUST have:
+#   binding: string (app-side env name root: <BINDING>_HOST etc.)
+#   type:    string (AppCo chart name; v1alpha1 supports postgresql, redis, grafana)
+# Plus type-specific auth/persistence/metrics/ingress/bootstrap fields per
+# rda-devx-catalog/SCHEMA.md. The legacy <chart>.* blocks below remain in
+# values.yaml for sub-chart resolution; the rda CLI pre-processor (Phase 1.5)
+# will keep them in sync with services[].
+apiVersion: rda.suse.com/v1alpha1
+services: []
+
+
 # --- application config ---
 name: ""
 replicas: 1

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.9.0
+  version: 0.10.0
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.9.0
+    version: 0.10.0
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
Implements Phase 1 of the unified DSL described in `idefxH/rda-devx-catalog/PROPOSAL.md`.

Coexistence with legacy `<chart>.*` blocks per the Helm sub-chart values constraint (Implementation note in PROPOSAL.md). Phase 1.5 will be the rda CLI pre-processor that auto-generates the legacy blocks from services[].

Closes part of #5 (helpers refactor — Phase 1 scope).
Companion to #4 (CATALOG.md mapping documentation, separate PR).

## Verified

- Legacy path: `services: []` → existing behavior preserved
- DSL path: services[] non-empty → new `<release>-<binding>-binding` secrets + env projected
- Drift: dual sources of truth disagreeing fails the chart with a clear hint