### PR TITLE
feat(library v0.10.1): source-of-truth annotations on DSL-rendered Secrets

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/_helpers.tpl
+++ b/library-chart/templates/_helpers.tpl
@@ -156,6 +156,13 @@ metadata:
     {{- include "suse-library.labels" $root | nindent 4 }}
     service.binding/binding-name: {{ $svc.binding }}
     service.binding/binding-type: {{ $svc.type }}
+  annotations:
+    # rda.suse.com/source documents which DSL key this resource was generated from.
+    # Manifesto principle: learning. Devs who inspect a Secret can trace it back
+    # to their values.yaml without having to dive into helper code.
+    # See idefxH/rda-devx-catalog/PROPOSAL.md (Manifesto re-read amendment).
+    rda.suse.com/source: "services[binding={{ $svc.binding }}].type={{ $svc.type }}"
+    rda.suse.com/helper: "suse-library.dsl.bindingSecretFrom"
 type: Opaque
 stringData:
   type: {{ $svc.type | quote }}

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.10.0
+  version: 0.10.1
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.10.0
+    version: 0.10.1
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
Closes #35.

Each Secret rendered from `services[]` carries:
- `rda.suse.com/source: services[binding=<x>].type=<y>`
- `rda.suse.com/helper: suse-library.dsl.bindingSecretFrom`

A dev who inspects `kubectl get secret demo-database-binding -o yaml` sees the DSL key responsible for it. Aligns with the learning manifesto principle.

Verified rendering in helm template ; library bumped to 0.10.1 ; suse-library copy re-vendored under `templates/web-nodejs/chart/charts/`.