### PR TITLE
feat(library v0.10.2): DSL ↔ passthrough collision detection (fail loud)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/_helpers.tpl
+++ b/library-chart/templates/_helpers.tpl
@@ -139,6 +139,91 @@ The set of projected keys per service type is documented in CATALOG.md.
 {{- end -}}
 
 {{/*
+`suse-library.dsl.validatePassthrough` fails loud when a service entry sets
+the same AppCo chart path both via the unified DSL fields and via the
+service's `passthrough:` block. The DSL is the recommended path; passthrough
+is the escape hatch for fields the DSL doesn't cover. When they collide,
+silently dropping either value would hide developer intent — so we fail
+with both locations and a "pick one" hint.
+
+Documented in idefxH/rda-docs/concepts/passthrough.md (rule #3) and
+idefxH/rda-docs/concepts/dsl.md (Validation check #4). Implementation of
+idefxH/rda-opinion-bundle-example#37.
+
+Sentinel pattern: `_RDA_NONE_` distinguishes "not set" from "set to a
+falsy value" (e.g. `enabled: false`). A non-sentinel value on both sides
+of a known DSL↔passthrough mapping triggers the fail.
+*/}}
+{{- define "suse-library.dsl.validatePassthrough" -}}
+{{- $sentinel := "_RDA_NONE_" -}}
+{{- range $i, $svc := .Values.services -}}
+{{- $type := $svc.type -}}
+{{- $pt := $svc.passthrough | default dict -}}
+{{- if eq $type "postgresql" -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "persistence.enabled" "ptPath" "persistence.enabled" "dslKeys" (list "persistence" "enabled") "ptKeys" (list "persistence" "enabled")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "persistence.size" "ptPath" "persistence.size" "dslKeys" (list "persistence" "size") "ptKeys" (list "persistence" "size")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "metrics.enabled" "ptPath" "metrics.enabled" "dslKeys" (list "metrics" "enabled") "ptKeys" (list "metrics" "enabled")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.admin.password" "ptPath" "auth.postgresPassword" "dslKeys" (list "auth" "admin" "password") "ptKeys" (list "auth" "postgresPassword")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.user.name" "ptPath" "auth.username" "dslKeys" (list "auth" "user" "name") "ptKeys" (list "auth" "username")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.user.password" "ptPath" "auth.password" "dslKeys" (list "auth" "user" "password") "ptKeys" (list "auth" "password")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.user.database" "ptPath" "auth.database" "dslKeys" (list "auth" "user" "database") "ptKeys" (list "auth" "database")) -}}
+{{- else if eq $type "redis" -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.password" "ptPath" "auth.password" "dslKeys" (list "auth" "password") "ptKeys" (list "auth" "password")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "persistence.enabled" "ptPath" "master.persistence.enabled" "dslKeys" (list "persistence" "enabled") "ptKeys" (list "master" "persistence" "enabled")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "metrics.enabled" "ptPath" "metrics.enabled" "dslKeys" (list "metrics" "enabled") "ptKeys" (list "metrics" "enabled")) -}}
+{{- else if eq $type "grafana" -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.admin.name" "ptPath" "adminUser" "dslKeys" (list "auth" "admin" "name") "ptKeys" (list "adminUser")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.admin.password" "ptPath" "adminPassword" "dslKeys" (list "auth" "admin" "password") "ptKeys" (list "adminPassword")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "ingress.enabled" "ptPath" "ingress.enabled" "dslKeys" (list "ingress" "enabled") "ptKeys" (list "ingress" "enabled")) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+`suse-library.dsl._collide` is the per-pair check called from validatePassthrough.
+Inputs: svc, pt (passthrough block), sentinel, dslPath/ptPath (display strings
+for the error message), dslKeys/ptKeys (lists of nested key names for `dig`).
+
+Note: helm's `dig` walks N keys with a final default. We pass our sentinel as
+the default so we can distinguish "not set" from "set to a falsy value".
+*/}}
+{{- define "suse-library.dsl._collide" -}}
+{{- $svc := .svc -}}
+{{- $pt := .pt -}}
+{{- $sentinel := .sentinel -}}
+{{- $dslVal := include "suse-library.dsl._dig" (dict "obj" $svc "keys" .dslKeys "sentinel" $sentinel) -}}
+{{- $ptVal := include "suse-library.dsl._dig" (dict "obj" $pt "keys" .ptKeys "sentinel" $sentinel) -}}
+{{- if and (ne $dslVal $sentinel) (ne $ptVal $sentinel) -}}
+{{- fail (printf "services[binding=%s].%s is set both via the DSL (=%s) and via passthrough.%s (=%s). Pick one. The DSL is the recommended path; use passthrough only for fields the DSL doesn't cover. See idefxH/rda-docs/concepts/passthrough.md." $svc.binding .dslPath $dslVal .ptPath $ptVal) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+`suse-library.dsl._dig` walks a nested map by a list of keys and returns the
+leaf value as a string, or the sentinel string when any intermediate key is
+missing. Helm's built-in `dig` works for known-depth lookups but is awkward
+for variable-length lists; this wrapper keeps the call sites uniform.
+*/}}
+{{- define "suse-library.dsl._dig" -}}
+{{- $obj := .obj -}}
+{{- $sentinel := .sentinel -}}
+{{- $found := true -}}
+{{- $cur := $obj -}}
+{{- range $k := .keys -}}
+{{- if and $found (kindIs "map" $cur) (hasKey $cur $k) -}}
+{{- $cur = index $cur $k -}}
+{{- else -}}
+{{- $found = false -}}
+{{- end -}}
+{{- end -}}
+{{- if $found -}}
+{{- $cur | toString -}}
+{{- else -}}
+{{- $sentinel -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 `suse-library.dsl.bindingSecretFrom` renders a SBS binding-secret for a
 single DSL service entry. Used by binding-secret.yaml.
 */}}

--- a/library-chart/templates/binding-secret.yaml
+++ b/library-chart/templates/binding-secret.yaml
@@ -22,6 +22,8 @@
 
 {{- /* DSL consistency check first — fails loud on drift */ -}}
 {{- include "suse-library.dsl.validateConsistency" . -}}
+{{- /* DSL ↔ passthrough collision check — fails loud, see #37 */ -}}
+{{- include "suse-library.dsl.validatePassthrough" . -}}
 
 {{- if .Values.services -}}
 

--- a/library-chart/tests/passthrough-collision/01-collision-persistence-enabled.values.yaml
+++ b/library-chart/tests/passthrough-collision/01-collision-persistence-enabled.values.yaml
@@ -1,0 +1,13 @@
+services:
+  - binding: database
+    type: postgresql
+    auth:
+      user:
+        name: app
+        password: dev-pw
+        database: demo
+    persistence:
+      enabled: true
+    passthrough:
+      persistence:
+        enabled: false

--- a/library-chart/tests/passthrough-collision/02-collision-mapped-path.values.yaml
+++ b/library-chart/tests/passthrough-collision/02-collision-mapped-path.values.yaml
@@ -1,0 +1,11 @@
+services:
+  - binding: database
+    type: postgresql
+    auth:
+      user:
+        name: app
+        password: dev-from-dsl
+        database: demo
+    passthrough:
+      auth:
+        password: dev-from-passthrough

--- a/library-chart/tests/passthrough-collision/03-no-collision-different-paths.values.yaml
+++ b/library-chart/tests/passthrough-collision/03-no-collision-different-paths.values.yaml
@@ -1,0 +1,14 @@
+services:
+  - binding: database
+    type: postgresql
+    auth:
+      user:
+        name: app
+        password: dev-pw
+        database: demo
+    persistence:
+      enabled: true
+    passthrough:
+      primary:
+        nodeSelector:
+          disk: ssd

--- a/library-chart/tests/passthrough-collision/04-no-collision-deeper-passthrough.values.yaml
+++ b/library-chart/tests/passthrough-collision/04-no-collision-deeper-passthrough.values.yaml
@@ -1,0 +1,14 @@
+services:
+  - binding: database
+    type: postgresql
+    auth:
+      user:
+        name: app
+        password: dev-pw
+        database: demo
+    metrics:
+      enabled: true
+    passthrough:
+      metrics:
+        serviceMonitor:
+          enabled: true

--- a/library-chart/tests/passthrough-collision/05-multi-service-second-collides.values.yaml
+++ b/library-chart/tests/passthrough-collision/05-multi-service-second-collides.values.yaml
@@ -1,0 +1,17 @@
+services:
+  - binding: cache
+    type: redis
+    auth:
+      password: dev-pw
+  - binding: database
+    type: postgresql
+    auth:
+      user:
+        name: app
+        password: dev-pw
+        database: demo
+    persistence:
+      enabled: true
+    passthrough:
+      persistence:
+        enabled: false

--- a/library-chart/tests/passthrough-collision/06-redis-collision-master-prefix.values.yaml
+++ b/library-chart/tests/passthrough-collision/06-redis-collision-master-prefix.values.yaml
@@ -1,0 +1,11 @@
+services:
+  - binding: cache
+    type: redis
+    auth:
+      password: dev-pw
+    persistence:
+      enabled: false
+    passthrough:
+      master:
+        persistence:
+          enabled: true

--- a/library-chart/tests/passthrough-collision/run.sh
+++ b/library-chart/tests/passthrough-collision/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Test runner for the DSL ↔ passthrough collision detection helper.
+# Strategy: copy library-chart to a tmpdir, strip the AppCo dependencies
+# from Chart.yaml so 'helm template' doesn't need them vendored, then
+# run each fixture and assert the expected outcome.
+#
+# Each fixture's expected outcome is encoded in the filename prefix:
+#   '0[126]-collision-*' / '0[5]-multi-service-second-collides-*' must FAIL
+#   '0[34]-no-collision-*' must SUCCEED.
+# Failure cases also assert the binding name appears in the error.
+#
+# Usage: ./run.sh
+# Expects helm on PATH.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHART_SRC="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Copy chart and strip dependencies (we don't have AppCo creds in CI).
+cp -r "$CHART_SRC" "$WORK/library-chart"
+python3 -c "
+import re, sys
+p = '$WORK/library-chart/Chart.yaml'
+s = open(p).read()
+s = re.sub(r'\ndependencies:.*', '\n', s, flags=re.DOTALL)
+open(p, 'w').write(s)
+"
+
+CHART="$WORK/library-chart"
+PASS=0
+FAIL=0
+
+run_one() {
+    local fixture="$1"
+    local expect="$2"
+    local must_contain="${3:-}"
+    local name="$(basename "$fixture")"
+
+    local out
+    if out=$(helm template testrelease "$CHART" --values "$fixture" 2>&1); then
+        local got=pass
+    else
+        local got=fail
+    fi
+
+    if [[ "$got" != "$expect" ]]; then
+        echo "✗ $name: expected $expect, got $got"
+        echo "--- output ---"
+        echo "$out" | head -8
+        echo "--- end ---"
+        FAIL=$((FAIL+1))
+        return
+    fi
+
+    if [[ -n "$must_contain" ]] && ! grep -qF "$must_contain" <<<"$out"; then
+        echo "✗ $name: output missing required substring \"$must_contain\""
+        echo "--- output ---"
+        echo "$out" | head -8
+        echo "--- end ---"
+        FAIL=$((FAIL+1))
+        return
+    fi
+
+    echo "✓ $name"
+    PASS=$((PASS+1))
+}
+
+run_one "$SCRIPT_DIR/01-collision-persistence-enabled.values.yaml" fail "binding=database"
+run_one "$SCRIPT_DIR/02-collision-mapped-path.values.yaml"          fail "binding=database"
+run_one "$SCRIPT_DIR/03-no-collision-different-paths.values.yaml"   pass
+run_one "$SCRIPT_DIR/04-no-collision-deeper-passthrough.values.yaml" pass
+run_one "$SCRIPT_DIR/05-multi-service-second-collides.values.yaml"  fail "binding=database"
+run_one "$SCRIPT_DIR/06-redis-collision-master-prefix.values.yaml"  fail "binding=cache"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+exit $FAIL


### PR DESCRIPTION
Closes #37.

## What

Adds `suse-library.dsl.validatePassthrough` helper. When a service entry sets the same AppCo chart path both via the unified DSL and via `passthrough:`, `helm template` now fails with both locations and a 'pick one' hint:

```
Error: services[binding=database].persistence.enabled is set both via the DSL (=true)
and via passthrough.persistence.enabled (=false). Pick one. The DSL is the
recommended path; use passthrough only for fields the DSL doesn't cover.
See idefxH/rda-docs/concepts/passthrough.md.
```

## Why

The previous behaviour was 'passthrough wins, silently'. That contradicts the manifesto principles of **learning** (nothing should be hidden), **nudge** (the easy path should be the right path), and **autonomy** (the dev should see the consequences of what they typed). The fix aligns DSL/passthrough collisions with the existing DSL/legacy drift check (`validateConsistency`) — both fail loud now.

The docs in `rda-docs` were corrected last sprint to claim this behavior; this PR makes the claim true.

## Implementation

- `library-chart/templates/_helpers.tpl`:
  - `suse-library.dsl.validatePassthrough` iterates `services[]`; per type, calls `_collide` for each known DSL ↔ AppCo path mapping.
  - `_collide` uses a sentinel (`_RDA_NONE_`) to distinguish 'not set' from 'set to a falsy value' (e.g. `enabled: false` is a real value, not absence).
  - `_dig` walks a nested map by a key list.
  - Phase 1 catalogue covers postgresql (7 mappings), redis (3), grafana (3). Adding a service type is a matter of appending include calls.
- `library-chart/templates/binding-secret.yaml`: calls `validatePassthrough` right after `validateConsistency`. Any project that renders the binding secrets exercises the check.
- `library-chart/Chart.yaml`: bumped 0.10.1 → 0.10.2.

## Tests

`library-chart/tests/passthrough-collision/run.sh` runs 6 `helm template` fixtures (with deps stripped to avoid AppCo creds in CI):

| # | Scenario | Expected |
|---|---|---|
| 01 | collision on `persistence.enabled` (same path) | fail with binding=database |
| 02 | collision on `auth.user.password` ↔ `auth.password` (mapped) | fail with binding=database |
| 03 | passthrough writes `primary.nodeSelector` (DSL doesn't touch) | pass |
| 04 | DSL leaf vs passthrough deeper key (`metrics.enabled` vs `metrics.serviceMonitor.enabled`) | pass |
| 05 | multi-service, second entry collides | fail naming the second binding |
| 06 | redis with `master.` prefix mapping | fail with binding=cache |

```
Results: 6 passed, 0 failed.
```

## Forward compat

Adding new service types to the catalogue: extend `validatePassthrough` with the new type's DSL→AppCo path mappings (one `include _collide` per pair). The `_collide` and `_dig` helpers are generic.