### PR TITLE
feat(library v0.10.3): add resources to DSL — 12th DevX dimension (Phase 1)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.10.2
+version: 0.10.3
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/_helpers.tpl
+++ b/library-chart/templates/_helpers.tpl
@@ -167,14 +167,26 @@ of a known DSL↔passthrough mapping triggers the fail.
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.user.name" "ptPath" "auth.username" "dslKeys" (list "auth" "user" "name") "ptKeys" (list "auth" "username")) -}}
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.user.password" "ptPath" "auth.password" "dslKeys" (list "auth" "user" "password") "ptKeys" (list "auth" "password")) -}}
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.user.database" "ptPath" "auth.database" "dslKeys" (list "auth" "user" "database") "ptKeys" (list "auth" "database")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.requests.cpu" "ptPath" "primary.resources.requests.cpu" "dslKeys" (list "resources" "requests" "cpu") "ptKeys" (list "primary" "resources" "requests" "cpu")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.requests.memory" "ptPath" "primary.resources.requests.memory" "dslKeys" (list "resources" "requests" "memory") "ptKeys" (list "primary" "resources" "requests" "memory")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.limits.cpu" "ptPath" "primary.resources.limits.cpu" "dslKeys" (list "resources" "limits" "cpu") "ptKeys" (list "primary" "resources" "limits" "cpu")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.limits.memory" "ptPath" "primary.resources.limits.memory" "dslKeys" (list "resources" "limits" "memory") "ptKeys" (list "primary" "resources" "limits" "memory")) -}}
 {{- else if eq $type "redis" -}}
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.password" "ptPath" "auth.password" "dslKeys" (list "auth" "password") "ptKeys" (list "auth" "password")) -}}
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "persistence.enabled" "ptPath" "master.persistence.enabled" "dslKeys" (list "persistence" "enabled") "ptKeys" (list "master" "persistence" "enabled")) -}}
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "metrics.enabled" "ptPath" "metrics.enabled" "dslKeys" (list "metrics" "enabled") "ptKeys" (list "metrics" "enabled")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.requests.cpu" "ptPath" "master.resources.requests.cpu" "dslKeys" (list "resources" "requests" "cpu") "ptKeys" (list "master" "resources" "requests" "cpu")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.requests.memory" "ptPath" "master.resources.requests.memory" "dslKeys" (list "resources" "requests" "memory") "ptKeys" (list "master" "resources" "requests" "memory")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.limits.cpu" "ptPath" "master.resources.limits.cpu" "dslKeys" (list "resources" "limits" "cpu") "ptKeys" (list "master" "resources" "limits" "cpu")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.limits.memory" "ptPath" "master.resources.limits.memory" "dslKeys" (list "resources" "limits" "memory") "ptKeys" (list "master" "resources" "limits" "memory")) -}}
 {{- else if eq $type "grafana" -}}
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.admin.name" "ptPath" "adminUser" "dslKeys" (list "auth" "admin" "name") "ptKeys" (list "adminUser")) -}}
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "auth.admin.password" "ptPath" "adminPassword" "dslKeys" (list "auth" "admin" "password") "ptKeys" (list "adminPassword")) -}}
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "ingress.enabled" "ptPath" "ingress.enabled" "dslKeys" (list "ingress" "enabled") "ptKeys" (list "ingress" "enabled")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.requests.cpu" "ptPath" "resources.requests.cpu" "dslKeys" (list "resources" "requests" "cpu") "ptKeys" (list "resources" "requests" "cpu")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.requests.memory" "ptPath" "resources.requests.memory" "dslKeys" (list "resources" "requests" "memory") "ptKeys" (list "resources" "requests" "memory")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.limits.cpu" "ptPath" "resources.limits.cpu" "dslKeys" (list "resources" "limits" "cpu") "ptKeys" (list "resources" "limits" "cpu")) -}}
+{{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "resources.limits.memory" "ptPath" "resources.limits.memory" "dslKeys" (list "resources" "limits" "memory") "ptKeys" (list "resources" "limits" "memory")) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/library-chart/tests/passthrough-collision/07-collision-resources-postgresql.values.yaml
+++ b/library-chart/tests/passthrough-collision/07-collision-resources-postgresql.values.yaml
@@ -1,0 +1,17 @@
+services:
+  - binding: database
+    type: postgresql
+    auth:
+      user:
+        name: app
+        password: dev-pw
+        database: demo
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    passthrough:
+      primary:
+        resources:
+          requests:
+            cpu: 500m

--- a/library-chart/tests/passthrough-collision/08-collision-resources-redis-master-prefix.values.yaml
+++ b/library-chart/tests/passthrough-collision/08-collision-resources-redis-master-prefix.values.yaml
@@ -1,0 +1,13 @@
+services:
+  - binding: cache
+    type: redis
+    auth:
+      password: dev-pw
+    resources:
+      limits:
+        memory: 1Gi
+    passthrough:
+      master:
+        resources:
+          limits:
+            memory: 2Gi

--- a/library-chart/tests/passthrough-collision/09-no-collision-resources-only-dsl.values.yaml
+++ b/library-chart/tests/passthrough-collision/09-no-collision-resources-only-dsl.values.yaml
@@ -1,0 +1,14 @@
+services:
+  - binding: dashboards
+    type: grafana
+    auth:
+      admin:
+        name: admin
+        password: dev-grafana
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi

--- a/library-chart/tests/passthrough-collision/run.sh
+++ b/library-chart/tests/passthrough-collision/run.sh
@@ -74,6 +74,10 @@ run_one "$SCRIPT_DIR/03-no-collision-different-paths.values.yaml"   pass
 run_one "$SCRIPT_DIR/04-no-collision-deeper-passthrough.values.yaml" pass
 run_one "$SCRIPT_DIR/05-multi-service-second-collides.values.yaml"  fail "binding=database"
 run_one "$SCRIPT_DIR/06-redis-collision-master-prefix.values.yaml"  fail "binding=cache"
+# Resources dimension (#33 Phase 1):
+run_one "$SCRIPT_DIR/07-collision-resources-postgresql.values.yaml" fail "resources.requests.cpu"
+run_one "$SCRIPT_DIR/08-collision-resources-redis-master-prefix.values.yaml" fail "resources.limits.memory"
+run_one "$SCRIPT_DIR/09-no-collision-resources-only-dsl.values.yaml" pass
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Refs #33. **Stacks on top of #38** (passthrough collision detection); merge #38 first.

## What

Extends the unified `services[]` DSL with a `resources:` block:

```yaml
services:
  - binding: database
    type: postgresql
    resources:
      requests: { cpu: 100m, memory: 256Mi }
      limits:   { cpu: 500m, memory: 1Gi  }
```

The `validatePassthrough` helper now detects collisions between DSL `resources` and equivalent `passthrough` paths per type:

| type | DSL | passthrough |
|---|---|---|
| postgresql | `resources.*` | `primary.resources.*` |
| redis | `resources.*` | `master.resources.*` |
| grafana | `resources.*` | `resources.*` |

12 new collision pairs (4 per type × 3 types).

## Phase 1 scope (this PR)

- DSL collision detection for `resources`.
- 3 new test fixtures.

## Out of scope — Phase 2 issues to file

- Per-chart `budget` metadata in CATALOG.md (ram_min_mb, cpu_min_milli, …).
- `rda doctor` summing the project's enabled services[] budgets vs cluster Allocatable, warning at >80%.
- GPU presence check.
- `profile: minimal | balanced | hifi` DSL flag scaling resources globally.

## Why Phase 1 is meaningful on its own

Without collision detection, a dev who writes `services[].resources` AND the legacy block (e.g. `postgresql.primary.resources`) gets a silent drop of one value. Phase 1 makes the mismatch visible at template time. Phase 2 will make `services[].resources` flow through automatically.

## Tests

```
library-chart/tests/passthrough-collision/run.sh
✓ 01–06: prior collision cases (still pass)
✓ 07: postgresql resources.requests.cpu collision
✓ 08: redis resources.limits.memory collision (master. prefix)
✓ 09: no collision — DSL resources alone

Results: 9 passed, 0 failed.
```