### PR TITLE
feat(library v0.10.4): provisioning: local | shared | external — Phase 1

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.10.3
+version: 0.10.4
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/_helpers.tpl
+++ b/library-chart/templates/_helpers.tpl
@@ -159,6 +159,15 @@ of a known DSL↔passthrough mapping triggers the fail.
 {{- range $i, $svc := .Values.services -}}
 {{- $type := $svc.type -}}
 {{- $pt := $svc.passthrough | default dict -}}
+{{- $provisioning := $svc.provisioning | default "local" -}}
+{{/*
+   Skip collision checks for non-local services: when provisioning is shared
+   or external, the AppCo sub-chart for $svc.type is NOT deployed for this
+   binding, so passthrough has no sub-chart values to collide with. Devs who
+   write passthrough on a shared/external service have only themselves to
+   blame; we can't usefully check the collision.
+*/}}
+{{- if ne $provisioning "local" -}}{{- continue -}}{{- end -}}
 {{- if eq $type "postgresql" -}}
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "persistence.enabled" "ptPath" "persistence.enabled" "dslKeys" (list "persistence" "enabled") "ptKeys" (list "persistence" "enabled")) -}}
 {{- include "suse-library.dsl._collide" (dict "svc" $svc "pt" $pt "sentinel" $sentinel "dslPath" "persistence.size" "ptPath" "persistence.size" "dslKeys" (list "persistence" "size") "ptKeys" (list "persistence" "size")) -}}
@@ -238,12 +247,64 @@ for variable-length lists; this wrapper keeps the call sites uniform.
 {{/*
 `suse-library.dsl.bindingSecretFrom` renders a SBS binding-secret for a
 single DSL service entry. Used by binding-secret.yaml.
+
+The host/port resolution depends on `services[].provisioning`:
+
+  - `local` (default): per-type convention (`<release>-<type>` for postgresql
+    and grafana, `<release>-<type>-master` for redis). The library deploys a
+    sub-chart and the binding-secret points at it.
+
+  - `shared`: read from `.Values.defaults.shared_services[<type>]`, which
+    the corp overlay populates with the canonical platform-services
+    endpoints. Fails loud if the overlay has no entry for this type.
+
+  - `external`: read from the per-service `endpoint:` block. Fails loud if
+    `endpoint:` is missing or incomplete.
+
+Credentials (auth.*) are sourced from the DSL the same way regardless of
+provisioning: the platform team manages the Vault path, projects reference
+it by path. See rda-docs/operator.md Step 6 for the pattern.
 */}}
 {{- define "suse-library.dsl.bindingSecretFrom" -}}
 {{- $svc := .svc -}}
 {{- $root := .root -}}
 {{- $release := $root.Release.Name -}}
-{{- $name := printf "%s-%s-binding" $release $svc.binding }}
+{{- $name := printf "%s-%s-binding" $release $svc.binding -}}
+{{- $provisioning := $svc.provisioning | default "local" -}}
+{{- if not (or (eq $provisioning "local") (or (eq $provisioning "shared") (eq $provisioning "external"))) -}}
+{{- fail (printf "services[binding=%s].provisioning must be 'local', 'shared', or 'external' (got %q). See rda-docs/concepts/dsl.md#provisioning." $svc.binding $provisioning) -}}
+{{- end -}}
+{{- /* Resolve host/port/scheme depending on provisioning. */ -}}
+{{- $host := "" -}}
+{{- $port := "" -}}
+{{- $scheme := "" -}}
+{{- if eq $provisioning "local" -}}
+  {{- if eq $svc.type "postgresql" -}}{{- $host = printf "%s-%s" $release $svc.type -}}{{- $port = "5432" -}}
+  {{- else if eq $svc.type "redis" -}}{{- $host = printf "%s-%s-master" $release $svc.type -}}{{- $port = "6379" -}}
+  {{- else if eq $svc.type "grafana" -}}{{- $host = printf "%s-%s" $release $svc.type -}}{{- $port = "80" -}}{{- $scheme = "http" -}}
+  {{- else -}}{{- fail (printf "Unsupported service type %q for binding %q in DSL v1alpha1 (provisioning=local). Supported types: postgresql, redis, grafana." $svc.type $svc.binding) -}}
+  {{- end -}}
+{{- else if eq $provisioning "shared" -}}
+  {{- /* dig() requires plain map[string]interface{}, but $root.Values is chartutil.Values; walk via index instead */ -}}
+  {{- $defaults := index $root.Values "defaults" | default dict -}}
+  {{- $sharedRoot := index $defaults "shared_services" | default dict -}}
+  {{- $sharedMap := index $sharedRoot $svc.type | default dict -}}
+  {{- $sharedHost := index $sharedMap "host" | default "" -}}
+  {{- if eq $sharedHost "" -}}
+  {{- fail (printf "services[binding=%s].provisioning=shared but the overlay has no defaults.shared_services.%s.host. Either configure the overlay (rda-docs/operator.md Step 6 → 'Pre-fill the endpoints in the overlay') or set provisioning: external with an explicit endpoint:." $svc.binding $svc.type) -}}
+  {{- end -}}
+  {{- $host = $sharedHost -}}
+  {{- $port = index $sharedMap "port" | default "" | toString -}}
+  {{- $scheme = index $sharedMap "scheme" | default "http" -}}
+{{- else if eq $provisioning "external" -}}
+  {{- $ep := $svc.endpoint | default dict -}}
+  {{- if eq (index $ep "host" | default "") "" -}}
+  {{- fail (printf "services[binding=%s].provisioning=external requires endpoint: { host, port, scheme } on the service entry." $svc.binding) -}}
+  {{- end -}}
+  {{- $host = $ep.host -}}
+  {{- $port = $ep.port | default "" | toString -}}
+  {{- $scheme = $ep.scheme | default "http" -}}
+{{- end -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -253,34 +314,28 @@ metadata:
     {{- include "suse-library.labels" $root | nindent 4 }}
     service.binding/binding-name: {{ $svc.binding }}
     service.binding/binding-type: {{ $svc.type }}
+    rda.suse.com/provisioning: {{ $provisioning | quote }}
   annotations:
     # rda.suse.com/source documents which DSL key this resource was generated from.
     # Manifesto principle: learning. Devs who inspect a Secret can trace it back
     # to their values.yaml without having to dive into helper code.
-    # See idefxH/rda-devx-catalog/PROPOSAL.md (Manifesto re-read amendment).
-    rda.suse.com/source: "services[binding={{ $svc.binding }}].type={{ $svc.type }}"
+    rda.suse.com/source: "services[binding={{ $svc.binding }}].type={{ $svc.type }}.provisioning={{ $provisioning }}"
     rda.suse.com/helper: "suse-library.dsl.bindingSecretFrom"
 type: Opaque
 stringData:
   type: {{ $svc.type | quote }}
   provider: rda-appco
+  host: {{ $host | quote }}
+  port: {{ $port | quote }}
 {{- if eq $svc.type "postgresql" }}
-  host: "{{ $release }}-{{ $svc.type }}"
-  port: "5432"
   username: {{ $svc.auth.user.name | default "app" | quote }}
   password: {{ required (printf "services[binding=%s].auth.user.password is required for type=postgresql" $svc.binding) $svc.auth.user.password | quote }}
   database: {{ required (printf "services[binding=%s].auth.user.database is required for type=postgresql" $svc.binding) $svc.auth.user.database | quote }}
 {{- else if eq $svc.type "redis" }}
-  host: "{{ $release }}-{{ $svc.type }}-master"
-  port: "6379"
   password: {{ required (printf "services[binding=%s].auth.password is required for type=redis" $svc.binding) $svc.auth.password | quote }}
 {{- else if eq $svc.type "grafana" }}
-  host: "{{ $release }}-{{ $svc.type }}"
-  port: "80"
-  url: "http://{{ $release }}-{{ $svc.type }}"
+  url: {{ printf "%s://%s:%s" $scheme $host $port | quote }}
   adminUser: {{ $svc.auth.admin.name | default "admin" | quote }}
   adminPassword: {{ required (printf "services[binding=%s].auth.admin.password is required for type=grafana" $svc.binding) $svc.auth.admin.password | quote }}
-{{- else }}
-{{- fail (printf "Unsupported service type %q for binding %q in DSL v1alpha1. Add a case to suse-library.dsl.bindingSecretFrom in _helpers.tpl. Supported in this version: postgresql, redis, grafana." $svc.type $svc.binding) }}
 {{- end }}
 {{- end -}}

--- a/library-chart/tests/provisioning/01-local-default-postgresql.values.yaml
+++ b/library-chart/tests/provisioning/01-local-default-postgresql.values.yaml
@@ -1,0 +1,8 @@
+services:
+  - binding: payments-db
+    type: postgresql
+    auth:
+      user:
+        name: app
+        password: dev-pw
+        database: payments

--- a/library-chart/tests/provisioning/02-shared-with-overlay-defaults-vault.values.yaml
+++ b/library-chart/tests/provisioning/02-shared-with-overlay-defaults-vault.values.yaml
@@ -1,0 +1,18 @@
+# Lookup is by .type — the overlay must have defaults.shared_services[<type>].
+# Phase 1 catalog supports postgresql/redis/grafana. We use postgresql here
+# as a stand-in for "any chart the team has centralised in platform-services".
+defaults:
+  shared_services:
+    postgresql:
+      host: shared-pg.platform-services
+      port: 5432
+      scheme: tcp
+services:
+  - binding: shared-events-db
+    type: postgresql
+    provisioning: shared
+    auth:
+      user:
+        name: app
+        password: ignored
+        database: ignored

--- a/library-chart/tests/provisioning/03-shared-without-overlay-fails.values.yaml
+++ b/library-chart/tests/provisioning/03-shared-without-overlay-fails.values.yaml
@@ -1,0 +1,9 @@
+services:
+  - binding: vault
+    type: postgresql
+    provisioning: shared          # no defaults.shared_services configured → must fail loud
+    auth:
+      user:
+        name: app
+        password: x
+        database: y

--- a/library-chart/tests/provisioning/04-external-with-endpoint.values.yaml
+++ b/library-chart/tests/provisioning/04-external-with-endpoint.values.yaml
@@ -1,0 +1,13 @@
+services:
+  - binding: legacy-events
+    type: postgresql
+    provisioning: external
+    endpoint:
+      host: legacy-postgres.corp.local
+      port: 5432
+      scheme: tcp
+    auth:
+      user:
+        name: app
+        password: dev-pw
+        database: legacy

--- a/library-chart/tests/provisioning/05-external-missing-endpoint-fails.values.yaml
+++ b/library-chart/tests/provisioning/05-external-missing-endpoint-fails.values.yaml
@@ -1,0 +1,9 @@
+services:
+  - binding: bad
+    type: postgresql
+    provisioning: external        # no endpoint: → must fail loud
+    auth:
+      user:
+        name: app
+        password: x
+        database: y

--- a/library-chart/tests/provisioning/06-bad-provisioning-value-fails.values.yaml
+++ b/library-chart/tests/provisioning/06-bad-provisioning-value-fails.values.yaml
@@ -1,0 +1,9 @@
+services:
+  - binding: typo
+    type: postgresql
+    provisioning: shred           # not a valid value
+    auth:
+      user:
+        name: app
+        password: x
+        database: y

--- a/library-chart/tests/provisioning/07-grafana-shared-uses-overlay-scheme.values.yaml
+++ b/library-chart/tests/provisioning/07-grafana-shared-uses-overlay-scheme.values.yaml
@@ -1,0 +1,14 @@
+defaults:
+  shared_services:
+    grafana:
+      host: grafana.platform-services
+      port: 3000
+      scheme: https
+services:
+  - binding: app-dashboards
+    type: grafana
+    provisioning: shared
+    auth:
+      admin:
+        name: admin
+        password: dev

--- a/library-chart/tests/provisioning/08-passthrough-on-shared-is-skipped.values.yaml
+++ b/library-chart/tests/provisioning/08-passthrough-on-shared-is-skipped.values.yaml
@@ -1,0 +1,20 @@
+defaults:
+  shared_services:
+    postgresql:
+      host: pg.platform-services
+      port: 5432
+      scheme: tcp
+services:
+  - binding: shared-pg
+    type: postgresql
+    provisioning: shared
+    persistence:
+      enabled: true
+    passthrough:
+      persistence:
+        enabled: false             # would collide if local; ignored when shared
+    auth:
+      user:
+        name: app
+        password: x
+        database: y

--- a/library-chart/tests/provisioning/run.sh
+++ b/library-chart/tests/provisioning/run.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Test runner for the provisioning: local|shared|external DSL field.
+# Strategy: copy library-chart to a tmpdir, strip the SUSE Application
+# Collection dependencies from Chart.yaml so 'helm template' doesn't need
+# them vendored, then run each fixture and assert the expected outcome.
+#
+# Usage: ./run.sh
+# Expects helm on PATH.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHART_SRC="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$CHART_SRC" "$WORK/library-chart"
+python3 -c "
+import re
+p = '$WORK/library-chart/Chart.yaml'
+s = open(p).read()
+s = re.sub(r'\ndependencies:.*', '\n', s, flags=re.DOTALL)
+open(p, 'w').write(s)
+"
+
+CHART="$WORK/library-chart"
+PASS=0
+FAIL=0
+
+run_one() {
+    local fixture="$1"
+    local expect="$2"        # 'fail' or 'pass'
+    local must_contain="${3:-}"
+    local name="$(basename "$fixture")"
+
+    local out
+    if out=$(helm template testrelease "$CHART" --values "$fixture" 2>&1); then
+        local got=pass
+    else
+        local got=fail
+    fi
+
+    if [[ "$got" != "$expect" ]]; then
+        echo "✗ $name: expected $expect, got $got"
+        echo "--- output ---"; echo "$out" | head -8; echo "--- end ---"
+        FAIL=$((FAIL+1)); return
+    fi
+
+    if [[ -n "$must_contain" ]] && ! grep -qF "$must_contain" <<<"$out"; then
+        echo "✗ $name: output missing required substring \"$must_contain\""
+        echo "--- output ---"; echo "$out" | head -8; echo "--- end ---"
+        FAIL=$((FAIL+1)); return
+    fi
+
+    echo "✓ $name"
+    PASS=$((PASS+1))
+}
+
+run_one "$SCRIPT_DIR/01-local-default-postgresql.values.yaml"       pass "host: \"testrelease-postgresql\""
+run_one "$SCRIPT_DIR/02-shared-with-overlay-defaults-vault.values.yaml"  pass "host: \"shared-pg.platform-services\""
+run_one "$SCRIPT_DIR/03-shared-without-overlay-fails.values.yaml"   fail "no defaults.shared_services.postgresql.host"
+run_one "$SCRIPT_DIR/04-external-with-endpoint.values.yaml"         pass "host: \"legacy-postgres.corp.local\""
+run_one "$SCRIPT_DIR/05-external-missing-endpoint-fails.values.yaml"  fail "requires endpoint:"
+run_one "$SCRIPT_DIR/06-bad-provisioning-value-fails.values.yaml"   fail "must be 'local', 'shared', or 'external'"
+run_one "$SCRIPT_DIR/07-grafana-shared-uses-overlay-scheme.values.yaml"  pass "https://grafana.platform-services:3000"
+run_one "$SCRIPT_DIR/08-passthrough-on-shared-is-skipped.values.yaml"   pass "host: \"pg.platform-services\""
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+exit $FAIL


### PR DESCRIPTION
Closes #42 (Phase 1).

Makes the DSL field [`services[].provisioning`](https://github.com/idefxH/rda-docs/blob/main/concepts/dsl.md) — which the docs already describe as Phase 1 first-class — actually do something at render time. The library's `bindingSecretFrom` helper now resolves host/port/scheme from one of three sources depending on the field's value.

## What

| `provisioning` | Source for host/port/scheme | Fail-loud condition |
|---|---|---|
| `local` (default) | per-type convention (`<release>-<type>`) | unsupported `type` |
| `shared` | `.Values.defaults.shared_services[<type>]` | overlay missing the entry |
| `external` | `services[].endpoint: { host, port, scheme }` | endpoint missing/incomplete |

Plus:
- New label on the rendered Secret: `rda.suse.com/provisioning: <value>`
- Source annotation extended: `rda.suse.com/source: services[binding=<x>].type=<y>.provisioning=<z>`
- `validatePassthrough` skips collision checks for non-local services (no sub-chart deployed → nothing to collide with)

## Tests — 8 new + 9 prior, all green

```
library-chart/tests/provisioning/run.sh
✓ 01: local default                       (host=<release>-postgresql)
✓ 02: shared with overlay defaults        (host=shared-pg.platform-services)
✓ 03: shared without overlay defaults     (fail loud)
✓ 04: external with endpoint              (host=legacy-postgres.corp.local)
✓ 05: external missing endpoint           (fail loud)
✓ 06: bad provisioning value              (fail loud)
✓ 07: grafana shared uses overlay scheme  (url=https://...)
✓ 08: passthrough on shared is skipped    (no collision error)

Results: 8 passed, 0 failed.

library-chart/tests/passthrough-collision/run.sh — 9 fixtures still pass.
```

## Out of scope (follow-ups)

- **Sub-chart enable/disable based on services[]** — for Phase 1, projects using `provisioning: shared` or `external` also flip the legacy `<chart>.enabled: false` flag so the SUSE Application Collection sub-chart actually doesn't deploy. The values.yaml schema is correct from day one; the library is catching up.
- **rda-cli `add-service --provisioning` flag** — separate PR coming in rda-cli.
- **rda explain catalog entries** for the new field — separate PR coming in rda-cli.

Library bumped 0.10.3 → 0.10.4.