### PR TITLE
feat(library v0.10.5): default metrics.enabled: true on every catalogued chart (#6)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.10.4
+version: 0.10.5
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/values.yaml
+++ b/library-chart/values.yaml
@@ -104,6 +104,13 @@ postgresql:
   persistence:
     enabled: false
   nodeCount: 1
+  # Out-of-the-box monitoring is the opinion bundle's value prop. Setting
+  # metrics.enabled: true at the library layer means downstream projects
+  # get the postgres_exporter sidecar by default; the chart's own default
+  # is false. Override locally with `postgresql.metrics.enabled: false`
+  # if your project explicitly does not want it. Refs bundle issue #6.
+  metrics:
+    enabled: true
 
 prometheus:
   enabled: false
@@ -131,3 +138,8 @@ grafana:
   adminPassword: ""
   persistence:
     enabled: false
+  # Self-monitoring on by default (Grafana exposes /metrics for its own
+  # process). Refs bundle issue #6 — out-of-the-box monitoring is the
+  # opinion bundle's value prop.
+  metrics:
+    enabled: true


### PR DESCRIPTION
**Closes #6.**

Out-of-the-box monitoring is the opinion bundle's value prop. Until now, the library defaulted `<chart>.enabled: false`; when a project opted in to e.g. `postgresql`, they got the chart's own defaults — which often have `metrics.enabled: false`. Result: postgres deployed but no `pg_exporter` sidecar, no `pg_up` metric in Prometheus. The dev had to discover that `postgresql.metrics.enabled: true` is a thing they had to set.

## Changes

In `library-chart/values.yaml`, override `metrics.enabled: true` for every catalogued AppCo chart that ships a metrics sub-block:

- `postgresql.metrics.enabled: true` (postgres_exporter sidecar)
- `grafana.metrics.enabled: true` (Grafana self-metrics)

Projects can still opt out with `<chart>.metrics.enabled: false` in their own `values.yaml` — the library default just shifts the path of least resistance toward "monitored by default".

## Why not redis / mariadb / etc.

The issue mentions `mariadb`, `redis`, etc. They aren't currently in `Chart.yaml`'s `dependencies` list, so there's no chart-level values block to override. When those deps land, the same default goes in alongside them.

`prometheus` itself is the metrics collector — no `metrics`-of-itself sub-block to flip.

## Tests

All existing suites still green:
- 9/9 `passthrough-collision` tests pass
- 8/8 `provisioning` tests pass

The `metrics.enabled` DSL collision check (added in v0.10.2) doesn't fire here. The new defaults live on the legacy chart-level block (`postgresql.metrics.enabled`), not via `services[].passthrough`. The collision check uses sentinel detection — it only triggers when both the DSL and the passthrough are explicitly set.

## Spec

- Library bumps `0.10.4` → `0.10.5`.

## Manifesto alignment

- **shift-left**: dev's `tilt up` brings up postgres with metrics, Prometheus picks them up, the dev sees `pg_up` on the bundled Grafana dashboard from minute one.
- **autonomy**: `postgresql.metrics.enabled: false` still works for the unusual case where the dev explicitly doesn't want it.
