### PR TITLE
feat(library v0.10.6): persistence-on by default for stateful charts (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ cd payment-service && tilt up
 - The default Dockerfile uses BCI base images. The `pack` buildpack-based
   build path lands when the SUSE-AppCo buildpacks are productized.
 
+## Persistence model
+
+The library chart's catalogue draws a line between **stateful** and **observability/cache** services:
+
+| Service     | `persistence.enabled` default | Why                                                                                |
+|-------------|-------------------------------|------------------------------------------------------------------------------------|
+| postgresql  | `true` (size: 1Gi)            | Seeded data must survive `tilt down` — devs lose trust if their data evaporates.   |
+| grafana     | `false`                       | Dashboards/datasources are config, not data. Re-seed from sidecar configmaps.      |
+| prometheus  | `false`                       | Scrape data is regenerated within minutes; persisting it on a laptop is overkill.  |
+
+The pattern: **flip persistence on for any chart whose value lives in seeded rows / blobs**, leave it off for anything whose state is regenerable from configuration.
+
+Override locally with `<chart>.persistence.enabled: false` (or `true`) in your project's `values.yaml`.
+
+### Nuke recipe — clean slate
+
+PVCs accumulate across re-installs (Helm doesn't delete them automatically). When you want a clean slate:
+
+```bash
+kubectl delete pvc -l app.kubernetes.io/instance=<release-name>
+# or for everything in a namespace:
+kubectl delete pvc --all -n <namespace>
+```
+
+Run this *after* `tilt down` / `helm uninstall` and *before* re-installing.
+
+`rda doctor` will surface a warning when accumulated PVCs grow past a threshold (issue tracked separately).
+
 ## License
 
 Apache-2.0 (templates, library chart, code skeletons).

--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.10.5
+version: 0.10.6
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/values.yaml
+++ b/library-chart/values.yaml
@@ -101,8 +101,17 @@ postgresql:
     database: ""
     username: ""
     password: ""
+  # Stateful service: persist by default so seeded data survives `tilt down`.
+  # Reproduction risk is high otherwise — devs lose trust in the dev loop
+  # when they rebuild and their data is gone. Refs bundle issue #7.
+  # Override locally with `postgresql.persistence.enabled: false` for the
+  # rare clean-slate-every-time workflow. Nuke accumulated PVCs across
+  # re-installs with:
+  #   kubectl delete pvc -l app.kubernetes.io/instance=<release>
+  # Default size is 1Gi (down from the AppCo chart's 8Gi) — laptop-friendly.
   persistence:
-    enabled: false
+    enabled: true
+    size: 1Gi
   nodeCount: 1
   # Out-of-the-box monitoring is the opinion bundle's value prop. Setting
   # metrics.enabled: true at the library layer means downstream projects


### PR DESCRIPTION
**Closes #7.**

Library defaulted `persistence.enabled: false` for every chart on the "dev is ephemeral" assumption. Reality bite: a dev hits `tilt down`, restarts later, all their seeded data is gone, they think their app is broken. Reproduction risk is high — devs lose trust in the dev loop.

## Changes

This PR draws a line between **stateful** and **observability / cache** services:

| Service     | `persistence.enabled` default | Why                                                                                |
|-------------|-------------------------------|------------------------------------------------------------------------------------|
| postgresql  | `true` (size: 1Gi)            | Seeded data must survive `tilt down`. Size dropped from chart default 8Gi → 1Gi.   |
| grafana     | `false` (unchanged)           | Dashboards/datasources are config, not data. Re-seed from sidecar configmaps.      |
| prometheus  | `false` (unchanged)           | Scrape data is regenerated within minutes; persisting it on a laptop is overkill.  |

The pattern, generalised in the README: **flip persistence on for any chart whose value lives in seeded rows / blobs**, leave it off for anything whose state is regenerable from configuration.

Override locally with `postgresql.persistence.enabled: false` (or any other chart) for the rare clean-slate-every-time workflow.

## Trade-off

PVCs accumulate across re-installs. README now documents the **nuke recipe**:

```bash
kubectl delete pvc -l app.kubernetes.io/instance=<release>
# or for everything in a namespace:
kubectl delete pvc --all -n <namespace>
```

A future `rda doctor` check will surface accumulated PVCs as a warning (separate issue).

## Why not redis / mariadb / etc.

Same reason as #6 / PR #45: those charts aren't yet in `Chart.yaml`'s `dependencies`, so there's no values block to flip. Same default lands when those deps are added.

## Tests

Full suite still green:
- 9/9 `passthrough-collision`
- 8/8 `provisioning`

## Spec

- Library bumps `0.10.5` → `0.10.6`.
- README gains a "Persistence model" section documenting the rule + nuke recipe.

## Manifesto alignment

- **shift-left**: a `tilt down` followed by `tilt up` doesn't lose seeded data — the dev loop matches what they'd expect from "pause and resume my work".
- **autonomy**: explicit `<chart>.persistence.enabled: false` works for the dev who explicitly wants ephemeral.
- **learning**: the README documents the rule and the nuke recipe so devs understand the trade-off — no magic.
