### PR TITLE
feat(library v0.10.7): factorize legacy binding helpers by category (#5)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.10.6
+version: 0.10.7
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/_helpers.tpl
+++ b/library-chart/templates/_helpers.tpl
@@ -339,3 +339,192 @@ stringData:
   adminPassword: {{ required (printf "services[binding=%s].auth.admin.password is required for type=grafana" $svc.binding) $svc.auth.admin.password | quote }}
 {{- end }}
 {{- end -}}
+
+{{/*
+─── Legacy-path helpers (issue #5) ──────────────────────────────────────
+
+The DSL services[] path is the future; the legacy `<chart>.enabled` path
+is what lets bundles <= v0.9 still render. Each helper below replaces a
+hand-rolled block of binding-secret + env-projection + volume wiring per
+chart. New legacy charts plug in by adding `<chart>.enabled` flags in
+values.yaml and one call site in deployment.yaml / binding-secret.yaml.
+
+Categories (matching the issue's taxonomy):
+  - sql-db       postgresql, mariadb, mysql       (host/port/user/password/database + DB_* aliases)
+  - url-only     prometheus                        (just URL)
+  - ui-with-admin grafana                          (URL + admin user/password)
+
+These helpers will be removed in Phase 1.5 when the rda CLI pre-processor
+auto-generates the legacy blocks from services[].
+*/}}
+
+{{/*
+suse-library.legacy.envForSqlDb — emit env vars for a SQL-database binding.
+Args (dict):
+  chart   string  AppCo chart name (e.g. "postgresql")
+  release string  release name (output of `include "suse-library.name" .`)
+Side effect: emits 10 env vars — 5 chart-prefixed (POSTGRESQL_*) + 5 DB_*
+semantic aliases. The aliases are emitted exactly once per call: callers
+wanting multiple SQL services must serialise — only the first SQL chart
+should pull DB_* aliases (the rest collide).
+*/}}
+{{- define "suse-library.legacy.envForSqlDb" -}}
+{{- $chart := .chart -}}
+{{- $rel := .release -}}
+{{- $upper := upper $chart -}}
+- {name: {{ $upper }}_HOST,     valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: host}}}
+- {name: {{ $upper }}_PORT,     valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: port}}}
+- {name: {{ $upper }}_USER,     valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: username}}}
+- {name: {{ $upper }}_PASSWORD, valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: password}}}
+- {name: {{ $upper }}_DATABASE, valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: database}}}
+- {name: DB_HOST,     valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: host}}}
+- {name: DB_PORT,     valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: port}}}
+- {name: DB_USER,     valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: username}}}
+- {name: DB_PASSWORD, valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: password}}}
+- {name: DB_NAME,     valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: database}}}
+{{- end -}}
+
+{{/*
+suse-library.legacy.envForUrlOnly — emit a single <CHART>_URL env var.
+Args (dict): chart, release. Used by url-only services like prometheus.
+*/}}
+{{- define "suse-library.legacy.envForUrlOnly" -}}
+{{- $chart := .chart -}}
+{{- $rel := .release -}}
+{{- $upper := upper $chart -}}
+- {name: {{ $upper }}_URL, valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: url}}}
+{{- end -}}
+
+{{/*
+suse-library.legacy.envForUiWithAdmin — emit URL + ADMIN_USER + ADMIN_PASSWORD.
+Args (dict): chart, release. Used by UI services with an admin login (grafana).
+*/}}
+{{- define "suse-library.legacy.envForUiWithAdmin" -}}
+{{- $chart := .chart -}}
+{{- $rel := .release -}}
+{{- $upper := upper $chart -}}
+- {name: {{ $upper }}_URL,            valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: url}}}
+- {name: {{ $upper }}_ADMIN_USER,     valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: adminUser}}}
+- {name: {{ $upper }}_ADMIN_PASSWORD, valueFrom: {secretKeyRef: {name: {{ $rel }}-{{ $chart }}-binding, key: adminPassword}}}
+{{- end -}}
+
+{{/*
+suse-library.legacy.bindingMount — emit the volumeMount line for a chart's
+SBS binding directory. Args (dict): chart.
+*/}}
+{{- define "suse-library.legacy.bindingMount" -}}
+- {name: binding-{{ .chart }}, mountPath: /bindings/{{ .chart }}, readOnly: true}
+{{- end -}}
+
+{{/*
+suse-library.legacy.bindingVolume — emit the volume entry for a chart's
+SBS binding Secret. Args (dict): chart, release.
+*/}}
+{{- define "suse-library.legacy.bindingVolume" -}}
+- name: binding-{{ .chart }}
+  secret: {secretName: {{ .release }}-{{ .chart }}-binding}
+{{- end -}}
+
+{{/*
+suse-library.legacy.sqlBindingSecret — emit a SQL-DB shaped binding Secret.
+Args (dict):
+  chart    string  AppCo chart name (postgresql, mariadb, mysql, ...)
+  port     string  port the chart's Service listens on (5432 for postgres)
+  hostSvc  string  Service name suffix the chart deploys (e.g. "<release>-postgresql")
+  root     dict    .Values + .Release passthrough (passed as the dot at the
+                   call site so `required` and labels work)
+*/}}
+{{- define "suse-library.legacy.sqlBindingSecret" -}}
+{{- $chart := .chart -}}
+{{- $port := .port -}}
+{{- $hostSvc := .hostSvc -}}
+{{- $root := .root -}}
+{{- $vals := index $root.Values $chart -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "suse-library.name" $root }}-{{ $chart }}-binding
+  labels:
+    {{- include "suse-library.labels" $root | nindent 4 }}
+    service.binding/binding-name: {{ $chart }}
+    service.binding/binding-type: {{ $chart }}
+type: Opaque
+stringData:
+  type: {{ $chart }}
+  provider: rda-appco
+  host: {{ $hostSvc | quote }}
+  port: {{ $port | quote }}
+  username: {{ required (printf "%s.auth.username is required when %s.enabled=true" $chart $chart) $vals.auth.username | quote }}
+  password: {{ required (printf "%s.auth.password is required when %s.enabled=true" $chart $chart) $vals.auth.password | quote }}
+  database: {{ required (printf "%s.auth.database is required when %s.enabled=true" $chart $chart) $vals.auth.database | quote }}
+{{- end -}}
+
+{{/*
+suse-library.legacy.urlBindingSecret — emit a URL-only binding Secret.
+Args (dict):
+  chart    string  AppCo chart name (prometheus, ...)
+  port     string  Service port (typically "80")
+  hostSvc  string  Service name (e.g. "<release>-prometheus-server")
+  root     dict    .Values + .Release passthrough
+*/}}
+{{- define "suse-library.legacy.urlBindingSecret" -}}
+{{- $chart := .chart -}}
+{{- $port := .port -}}
+{{- $hostSvc := .hostSvc -}}
+{{- $root := .root -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "suse-library.name" $root }}-{{ $chart }}-binding
+  labels:
+    {{- include "suse-library.labels" $root | nindent 4 }}
+    service.binding/binding-name: {{ $chart }}
+    service.binding/binding-type: {{ $chart }}
+type: Opaque
+stringData:
+  type: {{ $chart }}
+  provider: rda-appco
+  host: {{ $hostSvc | quote }}
+  port: {{ $port | quote }}
+  url: "http://{{ $hostSvc }}"
+{{- end -}}
+
+{{/*
+suse-library.legacy.uiBindingSecret — emit a UI-with-admin binding Secret.
+Args (dict):
+  chart       string  AppCo chart name (grafana, ...)
+  port        string  Service port (typically "80")
+  hostSvc     string  Service name (e.g. "<release>-grafana")
+  adminUser   string  default admin username (typically "admin")
+  adminField  string  the Values key holding the admin password (e.g. "adminPassword")
+  root        dict    .Values + .Release passthrough
+*/}}
+{{- define "suse-library.legacy.uiBindingSecret" -}}
+{{- $chart := .chart -}}
+{{- $port := .port -}}
+{{- $hostSvc := .hostSvc -}}
+{{- $adminUser := .adminUser -}}
+{{- $adminField := .adminField -}}
+{{- $root := .root -}}
+{{- $vals := index $root.Values $chart -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "suse-library.name" $root }}-{{ $chart }}-binding
+  labels:
+    {{- include "suse-library.labels" $root | nindent 4 }}
+    service.binding/binding-name: {{ $chart }}
+    service.binding/binding-type: {{ $chart }}
+type: Opaque
+stringData:
+  type: {{ $chart }}
+  provider: rda-appco
+  host: {{ $hostSvc | quote }}
+  port: {{ $port | quote }}
+  url: "http://{{ $hostSvc }}"
+  adminUser: {{ index $vals "adminUser" | default $adminUser | quote }}
+  adminPassword: {{ required (printf "%s.%s is required when %s.enabled=true" $chart $adminField $chart) (index $vals $adminField) | quote }}
+{{- end -}}

--- a/library-chart/templates/binding-secret.yaml
+++ b/library-chart/templates/binding-secret.yaml
@@ -34,67 +34,23 @@
 
 {{- else -}}
 
-{{/* Legacy path: gated by per-chart enabled flag */}}
+{{/*
+  Legacy path: gated by per-chart enabled flag. Each Secret is emitted via
+  a category helper (issue #5) — sql-db, url-only, ui-with-admin. New legacy
+  charts plug in by adding a single line below alongside their values.yaml
+  block; no copy-paste of the full Secret shape.
+*/}}
 
 {{- if .Values.postgresql.enabled }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "suse-library.name" . }}-postgresql-binding
-  labels:
-    {{- include "suse-library.labels" . | nindent 4 }}
-    service.binding/binding-name: postgresql
-    service.binding/binding-type: postgresql
-type: Opaque
-stringData:
-  type: postgresql
-  provider: rda-appco
-  host: "{{ .Release.Name }}-postgresql"
-  port: "5432"
-  username: {{ required "postgresql.auth.username is required when postgresql.enabled=true" .Values.postgresql.auth.username | quote }}
-  password: {{ required "postgresql.auth.password is required when postgresql.enabled=true" .Values.postgresql.auth.password | quote }}
-  database: {{ required "postgresql.auth.database is required when postgresql.enabled=true" .Values.postgresql.auth.database | quote }}
+{{ include "suse-library.legacy.sqlBindingSecret" (dict "chart" "postgresql" "port" "5432" "hostSvc" (printf "%s-postgresql" .Release.Name) "root" .) }}
 {{- end }}
 
 {{- if .Values.prometheus.enabled }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "suse-library.name" . }}-prometheus-binding
-  labels:
-    {{- include "suse-library.labels" . | nindent 4 }}
-    service.binding/binding-name: prometheus
-    service.binding/binding-type: prometheus
-type: Opaque
-stringData:
-  type: prometheus
-  provider: rda-appco
-  host: "{{ .Release.Name }}-prometheus-server"
-  port: "80"
-  url: "http://{{ .Release.Name }}-prometheus-server"
+{{ include "suse-library.legacy.urlBindingSecret" (dict "chart" "prometheus" "port" "80" "hostSvc" (printf "%s-prometheus-server" .Release.Name) "root" .) }}
 {{- end }}
 
 {{- if .Values.grafana.enabled }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "suse-library.name" . }}-grafana-binding
-  labels:
-    {{- include "suse-library.labels" . | nindent 4 }}
-    service.binding/binding-name: grafana
-    service.binding/binding-type: grafana
-type: Opaque
-stringData:
-  type: grafana
-  provider: rda-appco
-  host: "{{ .Release.Name }}-grafana"
-  port: "80"
-  url: "http://{{ .Release.Name }}-grafana"
-  adminUser: {{ .Values.grafana.adminUser | default "admin" | quote }}
-  adminPassword: {{ required "grafana.adminPassword is required when grafana.enabled=true" .Values.grafana.adminPassword | quote }}
+{{ include "suse-library.legacy.uiBindingSecret" (dict "chart" "grafana" "port" "80" "hostSvc" (printf "%s-grafana" .Release.Name) "adminUser" "admin" "adminField" "adminPassword" "root" .) }}
 {{- end }}
 
 {{- end -}}

--- a/library-chart/templates/deployment.yaml
+++ b/library-chart/templates/deployment.yaml
@@ -45,43 +45,37 @@ spec:
             # ─── DSL binding {{ $svc.binding }} (type {{ $svc.type }}) ───
             {{- include "suse-library.dsl.envFromBinding" (dict "svc" $svc "release" $.Release.Name) | nindent 12 }}
             {{- end }}
+            {{- /*
+                Legacy bindings (one block per chart). Each `if` arm calls a
+                category helper from _helpers.tpl (issue #5). New legacy
+                charts plug in here with a single line — no copy-paste of
+                the full env-var shape.
+            */}}
             {{- if .Values.postgresql.enabled }}
-            # ─── postgresql binding (12-factor projection) ───
+            # ─── postgresql binding (12-factor projection, sql-db category) ───
             # Apps that prefer SBS read /bindings/postgresql/<key> instead.
             # Both <CHART>_* (verbose, unambiguous) and DB_* (semantic
             # alias for portable SQL libs like Sequelize, Prisma, pg)
             # are projected from the same Secret.
-            - {name: POSTGRESQL_HOST,     valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-postgresql-binding, key: host}}}
-            - {name: POSTGRESQL_PORT,     valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-postgresql-binding, key: port}}}
-            - {name: POSTGRESQL_USER,     valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-postgresql-binding, key: username}}}
-            - {name: POSTGRESQL_PASSWORD, valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-postgresql-binding, key: password}}}
-            - {name: POSTGRESQL_DATABASE, valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-postgresql-binding, key: database}}}
-            # Semantic SQL aliases — first SQL chart enabled wins.
-            - {name: DB_HOST,     valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-postgresql-binding, key: host}}}
-            - {name: DB_PORT,     valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-postgresql-binding, key: port}}}
-            - {name: DB_USER,     valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-postgresql-binding, key: username}}}
-            - {name: DB_PASSWORD, valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-postgresql-binding, key: password}}}
-            - {name: DB_NAME,     valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-postgresql-binding, key: database}}}
+            {{- include "suse-library.legacy.envForSqlDb" (dict "chart" "postgresql" "release" (include "suse-library.name" .)) | nindent 12 }}
             {{- end }}
             {{- if .Values.prometheus.enabled }}
-            # ─── prometheus binding (12-factor projection) ───
-            - {name: PROMETHEUS_URL, valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-prometheus-binding, key: url}}}
+            # ─── prometheus binding (12-factor projection, url-only category) ───
+            {{- include "suse-library.legacy.envForUrlOnly" (dict "chart" "prometheus" "release" (include "suse-library.name" .)) | nindent 12 }}
             {{- end }}
             {{- if .Values.grafana.enabled }}
-            # ─── grafana binding (12-factor projection) ───
-            - {name: GRAFANA_URL,            valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-grafana-binding, key: url}}}
-            - {name: GRAFANA_ADMIN_USER,     valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-grafana-binding, key: adminUser}}}
-            - {name: GRAFANA_ADMIN_PASSWORD, valueFrom: {secretKeyRef: {name: {{ include "suse-library.name" . }}-grafana-binding, key: adminPassword}}}
+            # ─── grafana binding (12-factor projection, ui-with-admin category) ───
+            {{- include "suse-library.legacy.envForUiWithAdmin" (dict "chart" "grafana" "release" (include "suse-library.name" .)) | nindent 12 }}
             {{- end }}
           volumeMounts:
             {{- if .Values.postgresql.enabled }}
-            - {name: binding-postgresql, mountPath: /bindings/postgresql, readOnly: true}
+            {{- include "suse-library.legacy.bindingMount" (dict "chart" "postgresql") | nindent 12 }}
             {{- end }}
             {{- if .Values.prometheus.enabled }}
-            - {name: binding-prometheus, mountPath: /bindings/prometheus, readOnly: true}
+            {{- include "suse-library.legacy.bindingMount" (dict "chart" "prometheus") | nindent 12 }}
             {{- end }}
             {{- if .Values.grafana.enabled }}
-            - {name: binding-grafana, mountPath: /bindings/grafana, readOnly: true}
+            {{- include "suse-library.legacy.bindingMount" (dict "chart" "grafana") | nindent 12 }}
             {{- end }}
           livenessProbe:
             httpGet: {path: {{ .Values.probes.liveness.path }}, port: http}
@@ -94,14 +88,11 @@ spec:
           resources: {{ toYaml .Values.resources | nindent 12 }}
       volumes:
         {{- if .Values.postgresql.enabled }}
-        - name: binding-postgresql
-          secret: {secretName: {{ include "suse-library.name" . }}-postgresql-binding}
+        {{- include "suse-library.legacy.bindingVolume" (dict "chart" "postgresql" "release" (include "suse-library.name" .)) | nindent 8 }}
         {{- end }}
         {{- if .Values.prometheus.enabled }}
-        - name: binding-prometheus
-          secret: {secretName: {{ include "suse-library.name" . }}-prometheus-binding}
+        {{- include "suse-library.legacy.bindingVolume" (dict "chart" "prometheus" "release" (include "suse-library.name" .)) | nindent 8 }}
         {{- end }}
         {{- if .Values.grafana.enabled }}
-        - name: binding-grafana
-          secret: {secretName: {{ include "suse-library.name" . }}-grafana-binding}
+        {{- include "suse-library.legacy.bindingVolume" (dict "chart" "grafana" "release" (include "suse-library.name" .)) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
**Closes #5.**

The unified DSL `services[]` is the future, but the legacy `<chart>.enabled` path stays for back-compat with bundles ≤ v0.9. Until now, every legacy chart was hand-rolled in `deployment.yaml` + `binding-secret.yaml` — adding `mariadb` meant copy-pasting the `postgresql` block, renaming, and remembering to update both files in lockstep.

## Refactor

8 named templates in `_helpers.tpl`, organised by service category:

### env projection helpers (deployment.yaml)
| Helper                                    | Shape                                                  | Charts          |
|-------------------------------------------|--------------------------------------------------------|-----------------|
| `suse-library.legacy.envForSqlDb`         | `<CHART>_HOST/PORT/USER/PASSWORD/DATABASE` + `DB_*`    | postgresql, mariadb, mysql |
| `suse-library.legacy.envForUrlOnly`       | `<CHART>_URL`                                          | prometheus      |
| `suse-library.legacy.envForUiWithAdmin`   | `<CHART>_URL` + `_ADMIN_USER` + `_ADMIN_PASSWORD`      | grafana         |

### binding-secret helpers (binding-secret.yaml)
| Helper                                  | Shape                                  | Charts          |
|-----------------------------------------|----------------------------------------|-----------------|
| `suse-library.legacy.sqlBindingSecret`  | host/port/user/password/database       | postgresql, mariadb, mysql |
| `suse-library.legacy.urlBindingSecret`  | host/port/url                          | prometheus      |
| `suse-library.legacy.uiBindingSecret`   | host/port/url + adminUser + adminPassword | grafana       |

### generic mount/volume helpers
| Helper                                | Shape                          |
|---------------------------------------|--------------------------------|
| `suse-library.legacy.bindingMount`    | one-line volumeMount entry     |
| `suse-library.legacy.bindingVolume`   | one-line volume entry          |

## Result

`deployment.yaml` drops from ~115 lines of legacy boilerplate to single-line `include` calls per chart. Adding **mariadb** (a sql-db category chart) becomes:

```yaml
# values.yaml: add the chart block
mariadb: { enabled: false, auth: {...} }

# Chart.yaml: add the dep
- {name: mariadb, version: ..., repository: oci://..., condition: mariadb.enabled}

# deployment.yaml: 1-line include
{{- include "suse-library.legacy.envForSqlDb" (dict "chart" "mariadb" "release" (include "suse-library.name" .)) | nindent 12 }}

# binding-secret.yaml: 1-line include
{{- include "suse-library.legacy.sqlBindingSecret" (dict "chart" "mariadb" "port" "3306" "hostSvc" (printf "%s-mariadb" .Release.Name) "root" .) }}
```

vs. ~30 lines of copy-paste before.

## Verification

- **`helm template` output is semantically equivalent to pre-refactor.** YAML round-trip diff (parse → compare → re-emit): 5/5 docs match for the legacy fixture (postgresql + prometheus + grafana all enabled).
- Existing test suites still green:
  - 9/9 `passthrough-collision`
  - 8/8 `provisioning`
- `helm lint` clean.

## Out of scope

The chart-specific values shape (e.g. `auth.username` vs `auth.postgresPassword`) still varies per chart. The helper takes care of binding-secret **naming** and **env shape**; the chart-specific values pass-through stays in `values.yaml`. A future chart (mongodb, etc.) with a non-standard shape gets a new category helper, not an attempt to make the existing ones generic.

## Spec

- Library bumps `0.10.6` → `0.10.7`.

## Manifesto alignment

- **learning**: each helper is documented inline with its category and arg shape; the call site in `deployment.yaml` reads as "what category is this chart" rather than "what 30 lines of boilerplate do I need".
- **autonomy** (for the catalog maintainer): adding a new SQL chart no longer risks drift between `deployment.yaml` and `binding-secret.yaml`.

Unblocks the cleanup of the per-chart catalog additions: #10 (mariadb), #11 (redis/valkey), #14 (minio), and the rest of the chart-add backlog.
