### PR TITLE
feat(library v0.10.8): auto-Ingress for catalogued UI services (#8)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.10.7
+version: 0.10.8
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/ingress-ui.yaml
+++ b/library-chart/templates/ingress-ui.yaml
@@ -1,0 +1,62 @@
+{{/*
+  Auto-Ingress for catalogued UI services (bundle issue #8).
+
+  When a catalogued chart with a UI is enabled AND its `<chart>.ui.expose`
+  is true, the library renders an Ingress at:
+
+    <chart>.<release>.localhost  (default host)
+
+  Overrides per chart:
+    <chart>.ui.expose: false   — opt out
+    <chart>.ui.host: "..."     — custom host
+    <chart>.ui.path: "/"       — alternate path (default /)
+
+  Implementation: option 1 in the issue (library renders the Ingress
+  itself, knowing the chart's Service name + UI port from a per-chart
+  registry below). Option 2 (delegate to sub-chart's own ingress.*) is
+  rejected for now because the sub-charts' Ingress shapes differ enough
+  that maintaining a values-injection table is more brittle than just
+  rendering one consistent Ingress here.
+
+  The registry below mirrors CATALOG.md's connectivity dimension. To
+  add a new UI chart: add an entry to $uiCharts AND a `ui.expose: true`
+  default in values.yaml under that chart.
+*/}}
+{{- $uiCharts := dict
+  "grafana"    (dict "service" "grafana" "port" 80)
+  "prometheus" (dict "service" "prometheus-server" "port" 80)
+-}}
+{{- $rel := include "suse-library.name" . -}}
+{{- range $chart, $cfg := $uiCharts }}
+{{- $vals := index $.Values $chart | default dict -}}
+{{- if and (index $vals "enabled") (ne (index ($vals.ui | default dict) "expose") false) }}
+{{- $ui := $vals.ui | default dict -}}
+{{- $host := $ui.host | default (printf "%s.%s.localhost" $chart $rel) -}}
+{{- $path := $ui.path | default "/" -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ printf "%s-%s-ui" $rel $chart }}
+  labels:
+    {{- include "suse-library.labels" $ | nindent 4 }}
+    rda.suse.com/ui-for-chart: {{ $chart | quote }}
+  annotations:
+    rda.suse.com/source: {{ printf "%s.ui.expose" $chart | quote }}
+spec:
+  {{- with $.Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: {{ $path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ printf "%s-%s" $rel $cfg.service }}
+                port:
+                  number: {{ $cfg.port }}
+{{- end }}
+{{- end }}

--- a/library-chart/tests/auto-ingress-ui/01-grafana-and-prometheus-default.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/01-grafana-and-prometheus-default.values.yaml
@@ -1,0 +1,6 @@
+services: []
+grafana:
+  enabled: true
+  adminPassword: x
+prometheus:
+  enabled: true

--- a/library-chart/tests/auto-ingress-ui/02-grafana-only.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/02-grafana-only.values.yaml
@@ -1,0 +1,4 @@
+services: []
+grafana:
+  enabled: true
+  adminPassword: x

--- a/library-chart/tests/auto-ingress-ui/03-prometheus-only.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/03-prometheus-only.values.yaml
@@ -1,0 +1,3 @@
+services: []
+prometheus:
+  enabled: true

--- a/library-chart/tests/auto-ingress-ui/04-grafana-expose-false.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/04-grafana-expose-false.values.yaml
@@ -1,0 +1,5 @@
+services: []
+grafana:
+  enabled: true
+  adminPassword: x
+  ui: {expose: false}

--- a/library-chart/tests/auto-ingress-ui/05-custom-host.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/05-custom-host.values.yaml
@@ -1,0 +1,4 @@
+services: []
+prometheus:
+  enabled: true
+  ui: {host: "metrics.dev.local"}

--- a/library-chart/tests/auto-ingress-ui/06-all-disabled.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/06-all-disabled.values.yaml
@@ -1,0 +1,3 @@
+services: []
+grafana: {enabled: false}
+prometheus: {enabled: false}

--- a/library-chart/tests/auto-ingress-ui/07-project-ingress-no-ui.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/07-project-ingress-no-ui.values.yaml
@@ -1,0 +1,7 @@
+services: []
+ingress:
+  enabled: true
+  hosts:
+    - demo.localhost
+grafana: {enabled: false}
+prometheus: {enabled: false}

--- a/library-chart/tests/auto-ingress-ui/08-project-ingress-plus-grafana.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/08-project-ingress-plus-grafana.values.yaml
@@ -1,0 +1,8 @@
+services: []
+ingress:
+  enabled: true
+  hosts:
+    - app.localhost
+grafana:
+  enabled: true
+  adminPassword: x

--- a/library-chart/tests/auto-ingress-ui/run.sh
+++ b/library-chart/tests/auto-ingress-ui/run.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Test runner for auto-Ingress on catalogued UI services (issue #8).
+# Strategy mirrors the passthrough-collision suite: copy the chart to a
+# tmpdir, strip dependencies, then assert the rendered Ingress count and
+# substrings.
+#
+# Usage: ./run.sh
+# Expects helm on PATH.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHART_SRC="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$CHART_SRC" "$WORK/library-chart"
+python3 -c "
+import re
+p = '$WORK/library-chart/Chart.yaml'
+s = open(p).read()
+s = re.sub(r'\ndependencies:.*', '\n', s, flags=re.DOTALL)
+open(p, 'w').write(s)
+"
+
+CHART="$WORK/library-chart"
+PASS=0
+FAIL=0
+
+# Render values.yaml and assert:
+# - ingress_count: expected number of `kind: Ingress` in the rendered output
+# - must_contain: optional substring (e.g. host name) that must appear
+run_one() {
+    local fixture="$1"
+    local expected_count="$2"
+    local must_contain="${3:-}"
+    local name="$(basename "$fixture")"
+
+    local out
+    out=$(helm template testrel "$CHART" --values "$fixture" 2>&1)
+    local rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo "✗ $name: helm template failed (rc=$rc)"
+        echo "--- output ---"
+        echo "$out" | head -12
+        echo "--- end ---"
+        FAIL=$((FAIL+1))
+        return
+    fi
+
+    local got_count
+    got_count=$(grep -c "^kind: Ingress$" <<<"$out" || true)
+    if [[ "$got_count" != "$expected_count" ]]; then
+        echo "✗ $name: expected $expected_count Ingress(es), got $got_count"
+        echo "$out" | grep -E "^kind: Ingress|^  name:" | head -8
+        FAIL=$((FAIL+1))
+        return
+    fi
+
+    if [[ -n "$must_contain" ]] && ! grep -qF "$must_contain" <<<"$out"; then
+        echo "✗ $name: output missing required substring \"$must_contain\""
+        echo "$out" | grep -E "host:" | head -4
+        FAIL=$((FAIL+1))
+        return
+    fi
+
+    echo "✓ $name"
+    PASS=$((PASS+1))
+}
+
+# Both UI charts enabled, default ui.expose=true → 2 UI Ingresses
+run_one "$SCRIPT_DIR/01-grafana-and-prometheus-default.values.yaml" 2 "grafana.testrel.localhost"
+
+# grafana only → 1 UI Ingress
+run_one "$SCRIPT_DIR/02-grafana-only.values.yaml" 1 "grafana.testrel.localhost"
+
+# prometheus only → 1 UI Ingress, host has -server suffix in service backend
+run_one "$SCRIPT_DIR/03-prometheus-only.values.yaml" 1 "prometheus.testrel.localhost"
+
+# expose:false on grafana → 0 UI Ingresses (chart still enabled)
+run_one "$SCRIPT_DIR/04-grafana-expose-false.values.yaml" 0
+
+# Custom host via ui.host
+run_one "$SCRIPT_DIR/05-custom-host.values.yaml" 1 "metrics.dev.local"
+
+# All charts disabled → 0 UI Ingresses
+run_one "$SCRIPT_DIR/06-all-disabled.values.yaml" 0
+
+# Project ingress.enabled=true is unrelated — should still render only the
+# project's own Ingress (1) plus 0 UI Ingresses when no UI charts enabled
+run_one "$SCRIPT_DIR/07-project-ingress-no-ui.values.yaml" 1 "demo.localhost"
+
+# Project ingress + grafana UI → 2 Ingresses total
+run_one "$SCRIPT_DIR/08-project-ingress-plus-grafana.values.yaml" 2 "grafana.testrel.localhost"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+exit $FAIL

--- a/library-chart/values.yaml
+++ b/library-chart/values.yaml
@@ -132,6 +132,15 @@ prometheus:
   server:
     persistentVolume:
       enabled: false
+  # Auto-Ingress for the Prometheus UI. When prometheus.enabled is
+  # true, the library renders an Ingress at prometheus.<release>.localhost
+  # so the dev opens the expression browser from a browser without
+  # configuring a host explicitly. Override:
+  #   prometheus.ui.expose: false  # opt out
+  #   prometheus.ui.host: "..."    # custom host
+  # Refs bundle issue #8.
+  ui:
+    expose: true
   alertmanager:
     enabled: false
   prometheus-node-exporter:
@@ -152,3 +161,10 @@ grafana:
   # opinion bundle's value prop.
   metrics:
     enabled: true
+  # Auto-Ingress for the Grafana UI. When grafana.enabled is true, the
+  # library renders an Ingress at grafana.<release>.localhost. Override:
+  #   grafana.ui.expose: false  # opt out
+  #   grafana.ui.host: "..."    # custom host
+  # Refs bundle issue #8.
+  ui:
+    expose: true


### PR DESCRIPTION
**Closes #8.**

When a catalogued chart with a UI is enabled (currently `grafana`, `prometheus`), the library now renders an Ingress at `<chart>.<release>.localhost` so the dev opens the UI from a browser without any extra config. Default `ui.expose: true` on each UI chart's values block.

## Overrides

```yaml
grafana:
  ui:
    expose: false           # opt out
    host: "custom.local"    # custom host (defaults to <chart>.<release>.localhost)
    path: "/dashboards"     # alternate path (defaults to /)
```

## Implementation — option 1 from the issue

The library renders the Ingress itself from a per-chart UI registry inside `templates/ingress-ui.yaml`. The registry mirrors `CATALOG.md`'s connectivity dimension:

```
grafana    → service: <release>-grafana,            port 80
prometheus → service: <release>-prometheus-server,  port 80
```

**Option 2 (delegate to sub-chart's own `ingress.*` via values injection) was rejected** because Helm parent charts can't conditionally inject values into child charts at template time, and the sub-charts' ingress shapes differ enough that maintaining a per-chart values-injection table is more brittle than rendering one consistent Ingress here. The sub-chart's own `ingress.*` block stays available for projects that want full control (passthrough); the library's auto-Ingress is the convenience layer.

Adding a new UI chart is one entry in `$uiCharts` plus a `ui.expose: true` default in `values.yaml`. The pattern is documented inline in the template.

## Tests

`library-chart/tests/auto-ingress-ui/` — 8 sub-cases, all green:

| # | Scenario                                | Expected |
|---|-----------------------------------------|----------|
| 01 | grafana + prometheus default            | 2 Ingresses, hosts at `<chart>.testrel.localhost` |
| 02 | grafana only                            | 1 Ingress |
| 03 | prometheus only                         | 1 Ingress, backend points at `-prometheus-server` |
| 04 | grafana `ui.expose: false`              | 0 Ingresses (chart still enabled) |
| 05 | `ui.host` override                      | custom host honoured |
| 06 | all UI charts disabled                  | 0 Ingresses |
| 07 | project `ingress.enabled`, no UI charts | 1 Ingress (project's own only) |
| 08 | project ingress + grafana UI            | 2 Ingresses |

Existing suites still green:
- 9/9 `passthrough-collision`
- 8/8 `provisioning`

## Spec

- Library bumps `0.10.7` → `0.10.8`.

## Manifesto alignment

- **shift-left**: dev's `tilt up` brings up the UI Ingresses automatically; no copy-paste of the standard `ingress: { enabled: true, hosts: [...] }` block per chart.
- **autonomy**: explicit `<chart>.ui.expose: false` is one knob. The dev can also bypass entirely by leaving the library's Ingress alone and using the sub-chart's own `<chart>.ingress.*` (the two coexist; the library's path is named `<release>-<chart>-ui` so it doesn't collide with the sub-chart's default Ingress name).
- **learning**: the template documents the per-chart UI registry inline and points the next contributor at CATALOG.md's connectivity dimension.

## Tilt extension auto-link

The Tilt extension's auto-link feature (already in place) picks up `kind: Ingress` resources without further config. After this PR, devs see `grafana.demo.localhost` and `prometheus.demo.localhost` as clickable links in the Tilt UI immediately.
