### PR TITLE
fix(library v0.10.9, web-nodejs): DSL binding mounts + Tiltfile decoupled from values

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.10.8
+version: 0.10.9
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/deployment.yaml
+++ b/library-chart/templates/deployment.yaml
@@ -47,10 +47,15 @@ spec:
             {{- end }}
             {{- /*
                 Legacy bindings (one block per chart). Each `if` arm calls a
-                category helper from _helpers.tpl (issue #5). New legacy
-                charts plug in here with a single line — no copy-paste of
-                the full env-var shape.
+                category helper from _helpers.tpl (issue #5). The whole
+                legacy block is gated on `not services` so it doesn't double
+                up with the DSL path's env vars when both layers fire (the
+                DSL path's binding-secret has different keys + name shape
+                than the legacy one, so duplicate env names referencing
+                different Secrets would crash on render). Mirrors the
+                either/or branch in binding-secret.yaml.
             */}}
+            {{- if not .Values.services }}
             {{- if .Values.postgresql.enabled }}
             # ─── postgresql binding (12-factor projection, sql-db category) ───
             # Apps that prefer SBS read /bindings/postgresql/<key> instead.
@@ -67,7 +72,24 @@ spec:
             # ─── grafana binding (12-factor projection, ui-with-admin category) ───
             {{- include "suse-library.legacy.envForUiWithAdmin" (dict "chart" "grafana" "release" (include "suse-library.name" .)) | nindent 12 }}
             {{- end }}
+            {{- end }}
           volumeMounts:
+            {{- /*
+                DSL binding mounts (Phase 1). Each services[] entry that
+                isn't `provisioning: external` mounts its binding-secret at
+                /bindings/<binding>/, so apps following the Service Binding
+                Spec convention find their credentials there. external
+                services have no Secret to mount (the dev wired the
+                connection details elsewhere).
+            */}}
+            {{- range $i, $svc := .Values.services }}
+            {{- $prov := $svc.provisioning | default "local" }}
+            {{- if ne $prov "external" }}
+            - {name: {{ printf "binding-%s" $svc.binding }}, mountPath: {{ printf "/bindings/%s" $svc.binding }}, readOnly: true}
+            {{- end }}
+            {{- end }}
+            {{- /* Legacy mounts gated on not services (same rule as env block above). */}}
+            {{- if not .Values.services }}
             {{- if .Values.postgresql.enabled }}
             {{- include "suse-library.legacy.bindingMount" (dict "chart" "postgresql") | nindent 12 }}
             {{- end }}
@@ -76,6 +98,7 @@ spec:
             {{- end }}
             {{- if .Values.grafana.enabled }}
             {{- include "suse-library.legacy.bindingMount" (dict "chart" "grafana") | nindent 12 }}
+            {{- end }}
             {{- end }}
           livenessProbe:
             httpGet: {path: {{ .Values.probes.liveness.path }}, port: http}
@@ -87,6 +110,19 @@ spec:
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
       volumes:
+        {{- /*
+            DSL binding volumes — one Secret-backed volume per non-external
+            services[] entry. Pairs with the volumeMounts loop above.
+        */}}
+        {{- range $i, $svc := .Values.services }}
+        {{- $prov := $svc.provisioning | default "local" }}
+        {{- if ne $prov "external" }}
+        - name: {{ printf "binding-%s" $svc.binding }}
+          secret: {secretName: {{ printf "%s-%s-binding" (include "suse-library.name" $) $svc.binding }}}
+        {{- end }}
+        {{- end }}
+        {{- /* Legacy volumes gated on not services (same rule as env / mounts above). */}}
+        {{- if not .Values.services }}
         {{- if .Values.postgresql.enabled }}
         {{- include "suse-library.legacy.bindingVolume" (dict "chart" "postgresql" "release" (include "suse-library.name" .)) | nindent 8 }}
         {{- end }}
@@ -95,4 +131,5 @@ spec:
         {{- end }}
         {{- if .Values.grafana.enabled }}
         {{- include "suse-library.legacy.bindingVolume" (dict "chart" "grafana" "release" (include "suse-library.name" .)) | nindent 8 }}
+        {{- end }}
         {{- end }}

--- a/templates/web-nodejs/Tiltfile
+++ b/templates/web-nodejs/Tiltfile
@@ -15,23 +15,17 @@ v1alpha1.extension(
 )
 load('ext://suse-rda', 'suse_app')
 
-# `services` maps the actual K8s resource name (= what the AppCo chart
-# deploys) to the service type, used to surface the right port-forward.
-# - postgresql chart deploys <release>-postgresql
-# - prometheus chart deploys <release>-prometheus-server (alongside
-#   pushgateway, node-exporter, kube-state-metrics, alertmanager which
-#   the extension ignores by default)
-# - grafana chart deploys <release>-grafana
+# Service port-forwards are auto-discovered from `chart/values.yaml`:
+#   - DSL path:    every entry under `services[]` (the unified DSL).
+#   - Legacy path: every catalogued chart with `<chart>.enabled: true`.
 #
-# Uncomment the lines below to opt into the matching service. Each
-# service must also be enabled in values.yaml (suse-library.<chart>.enabled).
+# `rda add-service <type> <binding>` updates values.yaml; nothing in this
+# Tiltfile needs to change. To remove a port-forward, drop the entry from
+# values.yaml's services[] list (or unset `<chart>.enabled` on the legacy
+# path). To customise the host of a UI Ingress, see the library chart's
+# `<chart>.ui.host` knob.
 suse_app(
     name='{{ .Name }}',
     language='{{ .Language }}',
     port=8080,
-    services={
-        'postgresql':        'postgresql',
-        # 'prometheus-server': 'prometheus',
-        # 'grafana':           'grafana',
-    },
 )


### PR DESCRIPTION
**Two related fixes triggered by user feedback** — closes the "no database binding mounted" runtime symptom and the redundant `services={...}` dict in the generated Tiltfile.

## Fix #4: DSL binding volume mounts (the blocker)

`rda add-service postgresql <binding>` appends to `services[]`, the library generates a `<release>-<binding>-binding` Secret, env vars get projected, and… nothing mounts at `/bindings/<binding>/`. Apps that follow the Service Binding Spec (read `/bindings/<binding>/host`, etc.) found nothing — the dev's app logs `no database binding mounted` and quits.

The old `volumeMounts` / `volumes` blocks were only generated for the legacy `<chart>.enabled` path. The DSL path was a half-implementation.

**Now**, for every `services[]` entry whose `provisioning` is `local` or `shared`:

```yaml
volumeMounts:
  - {name: binding-<binding>, mountPath: /bindings/<binding>, readOnly: true}
volumes:
  - name: binding-<binding>
    secret: {secretName: <release>-<binding>-binding}
```

`external` services are still skipped (no in-cluster Secret to mount).

**Also**: the legacy env / mount / volume blocks are now gated on `{{- if not .Values.services }}` so they don't double up with the DSL path. `binding-secret.yaml` already had this XOR branching; `deployment.yaml` now matches.

## Fix #3: drop redundant `services={}` from web-nodejs Tiltfile

The generated Tiltfile carried:

```python
suse_app(
    name='{{ .Name }}',
    services={
        'postgresql':        'postgresql',
        # 'prometheus-server': 'prometheus',
        # 'grafana':           'grafana',
    },
)
```

…but `values.yaml` already lists every enabled service (via `services[]` or `<chart>.enabled`). The dict was redundant and went stale immediately after `rda add-service grafana` (the new entry never landed in the Tiltfile).

**Now** the Tiltfile drops the dict. Comment block explicitly says service port-forwards are auto-discovered from `values.yaml`. The matching `tilt-extension-suse-rda` change — having `suse_app()` actually read `values.yaml` to derive port-forwards — lands in a follow-up PR on that repo.

## Tests

Full library suite still green:
- 9/9 `passthrough-collision`
- 8/8 `provisioning`
- 8/8 `auto-ingress-ui`

## Bumps

Library: `0.10.8` → `0.10.9`.

## Manifesto alignment

- **shift-left**: dev's app actually finds its binding files at `tilt up` instead of crashing on missing /bindings/database/. The biggest paper-cut in the unified DSL was that the DSL was mostly fiction at runtime — this fixes it.
- **single source of truth**: removing the Tiltfile dict makes `values.yaml` the only place a dev configures their service stack. `rda add-service` updates exactly one file.
- **learning**: the new comment block in the Tiltfile explains where the port-forwards come from instead of asking the dev to maintain a parallel dict.

## Follow-ups

- Make `rda add-service` also set `<chart>.enabled: true` for catalogued local types so the sub-chart actually deploys (rda-cli PR, separate).
- Make `suse_app()` in `tilt-extension-suse-rda` read `values.yaml` for port-forwards (extension PR, separate).
