### PR TITLE
chore: align library_chart version pins with library-chart/Chart.yaml (0.11.0)

### DIFF
--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.10.1
+  version: 0.11.0
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.10.1
+    version: 0.11.0
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
Two version pins on the bundle were left at `0.10.1` after PR #57 (data-driven helpers) bumped `library-chart/Chart.yaml` to `0.11.0`:

- `rda-bundle.yaml:21` — `library_chart.version`
- `templates/web-nodejs/chart/Chart.yaml:11` — `suse-library` dep version

The manifest claimed `0.10.1` while shipping code from `0.11.0`. Scaffolded projects pinned the old version even though the data-driven helpers they relied on came from `0.11.0`+. Helm dep resolution kept working because `file://` pulls ignore the version field, but the pins were misleading.

Bumped both to `0.11.0` to match the ground truth.

## Tests

- `bash library-chart/tests/dsl-mappings-schema/run.sh` → ✓ schema valid
- `bash library-chart/tests/catalog-consistency/run.sh` → ✓ 3 charts consistent

## Follow-up

A doctor check or schema test that asserts `rda-bundle.yaml.library_chart.version == library-chart/Chart.yaml.version` would prevent this drift class. Trivial; can land in a separate PR.
