### PR TITLE
docs+template: Layer 2 README + values.yaml comment cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,55 @@ The library chart's catalogue (which AppCo charts you can opt into via `services
 
 Read CATALOG.md before adding a new chart to the bundle — every chart needs the 12 dimensions answered.
 
+## Template-time gates (Layer 2 of the layered-defense model)
+
+The library helpers run gates at every `helm template` invocation —
+every `tilt up`, every `rda upgrade`, every `rda promote`. These are
+**Layer 2** of RDA's four-layer defense model. The canonical reference
+is [`rda-docs/concepts/gates.md`](https://github.com/idefxH/rda-docs/blob/main/concepts/gates.md);
+the anchor in the rda CLI spec is the `BEHAVIOR: promote` NOTES in
+[`rda-cli/rda.md`](https://github.com/idefxH/rda-cli/blob/main/rda.md)
+under "Layered-defense model".
+
+Scoped to the rendered DSL — these gates fire before any manifest
+reaches a cluster, and run identically on the dev's laptop and in CI.
+
+### Active checks
+
+- **`suse-library.dsl.validateConsistency`** — fails the render if
+  any `services[]` entry has an empty `binding`, an unknown `type`
+  (not in `library-chart/dsl-mappings.yaml`), or a duplicate
+  `binding`. Catches typos before deployment.
+- **`suse-library.dsl.validatePassthrough`** — fails the render if
+  a service entry sets the same path twice: once via the DSL and
+  once via `passthrough:`. Catches DSL/legacy drift before
+  deployment. The collision keys come from each chart's
+  `values_mapping` in `dsl-mappings.yaml`, so the check stays in
+  sync with the catalogue.
+
+### Planned
+
+- **`dsl_drift`** — extends the passthrough collision check to also
+  flag the case where a project mixes the unified DSL with the
+  legacy chart-specific paths (`postgresql.auth.password` set
+  alongside `services[binding=db].auth.user.password`). Today the
+  collision check covers DSL ↔ passthrough; this extension covers
+  DSL ↔ legacy top-level. Tracked alongside the `rda promote`
+  `dsl_drift` gate stub on the CLI side.
+
+### Why template-time matters
+
+These checks are **complementary** to image-level gates (Layer 1,
+`suse_app(...)` in tilt-extension-suse-rda) and deployment-level
+gates (Layer 3, `rda promote`). The library helpers see what no
+other layer sees: the actual render of the project's DSL after
+overlay merge but before `kubectl apply`. A buildpack does not see
+the DSL; `rda promote`'s `forbidden_charts` does not see the
+rendered binding-secret structure; admission controllers see the
+final manifest but lose the `services[]` provenance. Failing here
+is the cheapest place to fail — `tilt up` exits in seconds with a
+specific DSL key in the error message.
+
 ## Persistence model
 
 The library chart's catalogue draws a line between **stateful** and **observability/cache** services:

--- a/templates/web-nodejs/chart/values.yaml
+++ b/templates/web-nodejs/chart/values.yaml
@@ -36,24 +36,16 @@ suse-library:
     - name: application-collection
 
   # ─── Backing services ──────────────────────────────────────────────
-  # Add via `rda add-service <type> <binding>`. Example for the
-  # bundled example app (which discovers a postgresql binding by
-  # type — see src/index.js findBindingByType):
+  # Add via `rda add-service <type> <binding>`, e.g.:
   #
-  # services:
-  #   - binding: payments-db
-  #     type: postgresql
-  #     auth:
-  #       user:
-  #         name: app
-  #         password: ""        # FILL IN — required, no default
-  #         database: payments
-  #     persistence:
-  #       enabled: true
-  #       size: 1Gi
-  #     metrics:
-  #       enabled: true
-  #     resources:
-  #       requests: { cpu: 100m, memory: 256Mi }
-  #       limits:   { cpu: 500m, memory: 1Gi }
-  services: []
+  #   rda add-service postgresql db
+  #
+  # The CLI appends a services[] entry here (block style) and auto-
+  # sets <chart>.enabled: true below so the AppCo sub-chart deploys.
+  # Before `tilt up`, edit the appended entry's auth.user.password —
+  # it ships empty by design (no plaintext default in the template).
+  #
+  # The bundled example app (src/index.js) discovers its DB binding
+  # by type (`findBindingByType('postgresql')`), so the binding name
+  # you pick is up to you — `db`, `orders-db`, anything unique
+  # within services[].


### PR DESCRIPTION
## What

Two cross-cutting changes from the Apr 30 product-assessment review and demo papercuts.

### 1. README — Template-time gates (Layer 2)

New section documenting the bundle's role in the four-layer defense model: the library helpers (`validateConsistency`, `validatePassthrough`) that fire on every `helm template` invocation. Explains why template-time is the cheapest place to fail (DSL render is the only step with the full overlay-merged values stack), names the planned `dsl_drift` extension, and cross-links the rda-cli spec anchor + the rda-docs end-to-end concept doc.

### 2. web-nodejs template — values.yaml cleanup

The previous backing-services comment example used `binding: payments-db` and `database: payments` — values that don't match what `rda add-service postgresql db` actually produces. Replace the long YAML-shaped example with a terse pointer to the command and a clarification that the binding name is up to the developer.

Also drops the trailing `services: []` so `add-service` creates a fresh block-style sequence rather than inheriting flow style from the pre-seeded empty list. (Pairs with the upstream fix in idefxH/rda-cli#58 which also clears Style on existing nodes — both fixes are independently sufficient.)

## Test

- README change is doc-only.
- values.yaml change verified against `rda add-service postgresql db`: appended entry renders as block-style YAML, sub-chart auto-enables, no DSL drift.

## Companion PRs

- idefxH/rda-cli#57 — spec layered-defense anchor (canonical reference)
- idefxH/rda-cli#58 — add-service emits block style (independent fix for old-template projects)
- idefxH/tilt-extension-suse-rda#8 — suse_app workload naming + README Layer 1 forward-looking spec
- idefxH/rda-docs (PR pending) — concepts/gates.md end-to-end concept doc
