### PR TITLE
feat(library): env_aliases + fail-loud on empty required + on missing <chart>.enabled

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.0
+version: 0.11.1
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -68,9 +68,13 @@ charts:
           - {key: provider, literal: rda-appco, skip_env: true}
           - {key: host, template: "{{ .Release.Name }}-postgresql"}
           - {key: port, literal: "5432"}
-          - {key: username, from_dsl: auth.user.name, default: app}
+          # username/database stay SBS-canonical in the Secret. The
+          # env_aliases also project under <BINDING>_USER /
+          # <BINDING>_NAME — the spellings libpq, JDBC, the `pg` npm
+          # package, sequelize, prisma, and most SQL clients expect.
+          - {key: username, from_dsl: auth.user.name, default: app, env_aliases: [user]}
           - {key: password, from_dsl: auth.user.password, required: true}
-          - {key: database, from_dsl: auth.user.database, required: true}
+          - {key: database, from_dsl: auth.user.database, required: true, env_aliases: [name]}
 
   redis:
     versions:

--- a/library-chart/templates/_helpers.tpl
+++ b/library-chart/templates/_helpers.tpl
@@ -145,6 +145,14 @@ checks:
   - every entry has a non-empty `binding`
   - every entry has a recognised `type` (must be in dsl-mappings.yaml)
   - bindings are unique within services[]
+  - for provisioning=local entries: <chart>.enabled must be true. The
+    Helm dependency `condition` field on library-chart/Chart.yaml gates
+    sub-chart resolution on that flag, and condition is evaluated at
+    dep-resolution time — BEFORE `_helpers.tpl` runs. So we can't auto-
+    derive the flag from services[]; we can only fail loud here when
+    they're out of sync. `rda add-service` writes both halves; this
+    check catches the case where someone removes <chart>.enabled
+    manually thinking it's redundant with the DSL entry.
 */}}
 {{- define "suse-library.dsl.validateConsistency" -}}
 {{- $mappings := include "suse-library.dsl.loadMappings" . | fromJson -}}
@@ -162,6 +170,18 @@ checks:
   {{- fail (printf "duplicate binding %q in services[]: each entry needs a unique binding name." $svc.binding) -}}
   {{- end -}}
   {{- $_ := set $seen $svc.binding true -}}
+  {{- /* Local provisioning requires the matching <chart>.enabled flag.
+         Helm's dep `condition` evaluates before this helper runs, so we
+         can only validate post-hoc — but the failure is clear enough
+         that the dev fixes it in one edit. */ -}}
+  {{- $provisioning := $svc.provisioning | default "local" -}}
+  {{- if eq $provisioning "local" -}}
+  {{- $chartBlock := index $.Values $svc.type | default dict -}}
+  {{- if not (eq (kindOf $chartBlock) "map") -}}{{- $chartBlock = dict -}}{{- end -}}
+  {{- if not (eq (index $chartBlock "enabled" | default false) true) -}}
+  {{- fail (printf "services[binding=%s].type=%s, provisioning=local — but suse-library.%s.enabled is not true. The Helm dep gates the sub-chart on `condition: %s.enabled`, and condition is evaluated at dep resolution time, so the DSL entry alone can't trigger the dep. Set:\n\n    suse-library:\n      %s:\n        enabled: true\n\n(Or run `rda add-service` which writes both halves automatically.) See rda-docs/concepts/dsl.md#why-the-enabled-flag-is-not-redundant." $svc.binding $svc.type $svc.type $svc.type $svc.type) -}}
+  {{- end -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -169,6 +189,14 @@ checks:
 suse-library.dsl.envFromBinding — project env vars from a binding-secret.
 For every key declared in the chart's binding_secret list, emit a
 { name: <BINDING>_<KEY>, valueFrom: { secretKeyRef: { ... } } } entry.
+
+When a binding_secret entry declares `env_aliases: [name1, name2]`, the
+helper emits ADDITIONAL env vars `<BINDING>_<NAMEn>` that all reference
+the SAME secret key. Use this to keep SBS-canonical key names in the
+Secret (username, database, ...) while also projecting the env-var
+spellings the broader ecosystem expects (libpq's PGUSER convention →
+DB_USER, JDBC's DB_NAME, etc.). Aliases never appear in the Secret's
+stringData — only as additional env-var bindings.
 
 Args (dict): svc, release.
 */}}
@@ -183,9 +211,17 @@ Args (dict): svc, release.
 {{- /* The env var name uses upper-snake-case: camelCase secret keys (adminUser)
        become ADMIN_USER, kebab-case keys (admin-user) become ADMIN_USER too.
        Sprig's `snakecase` does the camelCase split; replace handles dashes. */ -}}
-{{- $envKey := (index $entry "key" | snakecase | upper | replace "-" "_") }}
+{{- $secretKey := index $entry "key" -}}
+{{- $envKey := ($secretKey | snakecase | upper | replace "-" "_") }}
 - name: {{ printf "%s_%s" $bindingUpper $envKey }}
-  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: {{ index $entry "key" }} } }
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: {{ $secretKey }} } }
+{{- /* Optional aliases — additional env vars referencing the same Secret
+       key. Empty / missing list is fine; we just iterate and emit. */ -}}
+{{- range $alias := index $entry "env_aliases" | default list }}
+{{- $aliasEnvKey := ($alias | snakecase | upper | replace "-" "_") }}
+- name: {{ printf "%s_%s" $bindingUpper $aliasEnvKey }}
+  valueFrom: { secretKeyRef: { name: {{ $secret }}, key: {{ $secretKey }} } }
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -384,6 +420,13 @@ stringData:
   {{- end }}
   {{ $key }}: {{ $default | quote }}
   {{- else }}
+  {{- /* required:true also rejects empty strings — pg, mysql, redis, etc.
+         all treat an empty password as "no password" / fall back to env
+         vars / silently fail at runtime. Catching here makes the failure
+         loud at template time with a clear DSL key in the message. */ -}}
+  {{- if and $required (eq $val "") }}
+  {{- fail (printf "services[binding=%s].%s is required for type=%s but is empty (\"\"). Set a non-empty value before tilt up — most clients (pg, mysql, redis) treat an empty password as missing and silently fall back, producing a confusing runtime error rather than a clear template-time one. See rda-docs/concepts/dsl.md." $svc.binding $dslPath $svc.type) }}
+  {{- end }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- end }}

--- a/library-chart/tests/dsl-mappings-schema/check.py
+++ b/library-chart/tests/dsl-mappings-schema/check.py
@@ -25,6 +25,9 @@ Schema (mirrors the file's own header documentation):
               required:      <bool>            # only with from_dsl
               default:       <string>          # only with from_dsl
               skip_env:      <bool>            # optional
+              env_aliases:   <list of strings> # optional; emits additional
+                                               # env vars referencing the
+                                               # same Secret key
 
 Exit codes:
   0  schema valid
@@ -48,7 +51,7 @@ EXPECTED_API_VERSION = "rda.suse.com/dsl-mapping/v1alpha1"
 # guarantees collision detection in validatePassthrough computes the right
 # sub-path (it strips the chart-name prefix).
 RESERVED_BS_KEYS = {"key", "literal", "template", "from_dsl",
-                    "required", "default", "skip_env"}
+                    "required", "default", "skip_env", "env_aliases"}
 
 
 def err(errors, path, msg):
@@ -99,6 +102,35 @@ def check_binding_secret(errors, chart, vidx, bs):
         if "skip_env" in entry and not isinstance(entry["skip_env"], bool):
             err(errors, "%s.key=%s" % (path, key),
                 "skip_env must be bool")
+        if "env_aliases" in entry:
+            aliases = entry["env_aliases"]
+            if not isinstance(aliases, list):
+                err(errors, "%s.key=%s" % (path, key),
+                    "env_aliases must be a list of strings, got %s" %
+                    type(aliases).__name__)
+            else:
+                for ai, a in enumerate(aliases):
+                    if not isinstance(a, str) or not a:
+                        err(errors, "%s.key=%s.env_aliases[%d]" % (path, key, ai),
+                            "must be a non-empty string")
+                # An alias that re-spells the secret key as itself is
+                # a no-op; flag the typo. snakecase comparison covers
+                # camelCase / kebab-case equivalence.
+                import re
+                norm = lambda s: re.sub(r"[\W_]+", "", s.lower())
+                key_norm = norm(key)
+                for ai, a in enumerate(aliases):
+                    if isinstance(a, str) and norm(a) == key_norm:
+                        err(errors, "%s.key=%s.env_aliases[%d]" % (path, key, ai),
+                            "alias %r resolves to the same env-var name as the "
+                            "key %r — drop it (it would emit a duplicate env "
+                            "var entry on the Deployment)." % (a, key))
+        if "skip_env" in entry and entry.get("skip_env") and "env_aliases" in entry:
+            err(errors, "%s.key=%s" % (path, key),
+                "env_aliases on a skip_env entry is meaningless — the "
+                "primary env var is suppressed, so the aliases would be "
+                "the only env vars projected. Either drop skip_env or "
+                "drop env_aliases.")
 
 
 def check_values_mapping(errors, chart, vidx, vm):

--- a/library-chart/tests/env-aliases/01-postgres-emits-both-username-and-user.values.yaml
+++ b/library-chart/tests/env-aliases/01-postgres-emits-both-username-and-user.values.yaml
@@ -1,0 +1,18 @@
+# Smoke test: postgres binding should emit BOTH DB_USERNAME (SBS canonical)
+# AND DB_USER (env_alias for libpq/pg/jdbc compatibility).
+#
+# Note: this file is loaded directly against the library-chart, so values
+# are at the TOP level (not under suse-library:).
+services:
+  - binding: db
+    type: postgresql
+    auth:
+      admin: { password: "admin" }
+      user:
+        name: app
+        password: "pw"
+        database: demo
+    persistence: { enabled: false }
+
+postgresql:
+  enabled: true

--- a/library-chart/tests/env-aliases/run.sh
+++ b/library-chart/tests/env-aliases/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Smoke test for env_aliases: assert the rendered Deployment has both the
+# SBS-canonical env vars and the alias spellings.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHART_SRC="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$CHART_SRC" "$WORK/library-chart"
+python3 -c "
+import re
+p = '$WORK/library-chart/Chart.yaml'
+s = open(p).read()
+s = re.sub(r'\ndependencies:.*', '\n', s, flags=re.DOTALL)
+open(p, 'w').write(s)
+"
+
+CHART="$WORK/library-chart"
+FIXTURE="$SCRIPT_DIR/01-postgres-emits-both-username-and-user.values.yaml"
+
+OUT="$(helm template demo "$CHART" -f "$FIXTURE" 2>&1)"
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "✗ helm template failed:"
+    echo "$OUT"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+check() {
+    local needle="$1"
+    if echo "$OUT" | grep -q -F "$needle"; then
+        echo "✓ found: $needle"
+        PASS=$((PASS + 1))
+    else
+        echo "✗ missing: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# SBS canonical env vars
+check "name: DB_USERNAME"
+check "name: DB_PASSWORD"
+check "name: DB_DATABASE"
+check "name: DB_HOST"
+check "name: DB_PORT"
+
+# env_aliases
+check "name: DB_USER"
+check "name: DB_NAME"
+
+# Both DB_USERNAME and DB_USER reference the same Secret key 'username'
+# (the alias points at the original key, not its own copy in the Secret).
+USERNAME_REFS=$(echo "$OUT" | grep -A 1 "name: DB_USERNAME\|name: DB_USER" | grep -c "key: username")
+if [ "$USERNAME_REFS" -ne 2 ]; then
+    echo "✗ expected DB_USERNAME and DB_USER both to reference key: username, got $USERNAME_REFS matches"
+    FAIL=$((FAIL + 1))
+else
+    echo "✓ DB_USERNAME and DB_USER both reference key: username"
+    PASS=$((PASS + 1))
+fi
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ]

--- a/library-chart/tests/passthrough-collision/01-collision-persistence-enabled.values.yaml
+++ b/library-chart/tests/passthrough-collision/01-collision-persistence-enabled.values.yaml
@@ -11,3 +11,6 @@ services:
     passthrough:
       persistence:
         enabled: false
+
+postgresql:
+  enabled: true

--- a/library-chart/tests/passthrough-collision/02-collision-mapped-path.values.yaml
+++ b/library-chart/tests/passthrough-collision/02-collision-mapped-path.values.yaml
@@ -9,3 +9,6 @@ services:
     passthrough:
       auth:
         password: dev-from-passthrough
+
+postgresql:
+  enabled: true

--- a/library-chart/tests/passthrough-collision/03-no-collision-different-paths.values.yaml
+++ b/library-chart/tests/passthrough-collision/03-no-collision-different-paths.values.yaml
@@ -12,3 +12,6 @@ services:
       primary:
         nodeSelector:
           disk: ssd
+
+postgresql:
+  enabled: true

--- a/library-chart/tests/passthrough-collision/04-no-collision-deeper-passthrough.values.yaml
+++ b/library-chart/tests/passthrough-collision/04-no-collision-deeper-passthrough.values.yaml
@@ -12,3 +12,6 @@ services:
       metrics:
         serviceMonitor:
           enabled: true
+
+postgresql:
+  enabled: true

--- a/library-chart/tests/passthrough-collision/05-multi-service-second-collides.values.yaml
+++ b/library-chart/tests/passthrough-collision/05-multi-service-second-collides.values.yaml
@@ -15,3 +15,9 @@ services:
     passthrough:
       persistence:
         enabled: false
+
+postgresql:
+  enabled: true
+
+redis:
+  enabled: true

--- a/library-chart/tests/passthrough-collision/06-redis-collision-master-prefix.values.yaml
+++ b/library-chart/tests/passthrough-collision/06-redis-collision-master-prefix.values.yaml
@@ -9,3 +9,6 @@ services:
       master:
         persistence:
           enabled: true
+
+redis:
+  enabled: true

--- a/library-chart/tests/passthrough-collision/07-collision-resources-postgresql.values.yaml
+++ b/library-chart/tests/passthrough-collision/07-collision-resources-postgresql.values.yaml
@@ -15,3 +15,6 @@ services:
         resources:
           requests:
             cpu: 500m
+
+postgresql:
+  enabled: true

--- a/library-chart/tests/passthrough-collision/08-collision-resources-redis-master-prefix.values.yaml
+++ b/library-chart/tests/passthrough-collision/08-collision-resources-redis-master-prefix.values.yaml
@@ -11,3 +11,6 @@ services:
         resources:
           limits:
             memory: 2Gi
+
+redis:
+  enabled: true

--- a/library-chart/tests/passthrough-collision/09-no-collision-resources-only-dsl.values.yaml
+++ b/library-chart/tests/passthrough-collision/09-no-collision-resources-only-dsl.values.yaml
@@ -12,3 +12,6 @@ services:
       limits:
         cpu: 500m
         memory: 1Gi
+
+grafana:
+  enabled: true

--- a/library-chart/tests/provisioning/01-local-default-postgresql.values.yaml
+++ b/library-chart/tests/provisioning/01-local-default-postgresql.values.yaml
@@ -6,3 +6,6 @@ services:
         name: app
         password: dev-pw
         database: payments
+
+postgresql:
+  enabled: true

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.0
+  version: 0.11.1
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.11.0
+    version: 0.11.1
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
## What

Three additive changes to the library helpers, all surfaced by the Apr 30 live-demo papercut session. The PR turns three classes of opaque runtime errors into clear template-time messages.

### 1. `env_aliases` on `binding_secret` entries

New optional field on each `binding_secret` entry:

```yaml
- {key: username, from_dsl: auth.user.name, default: app, env_aliases: [user]}
- {key: database, from_dsl: auth.user.database, required: true, env_aliases: [name]}
```

The `envFromBinding` helper emits one additional `<BINDING>_<ALIAS>` env var per alias, all referencing the same Secret key. Lets us keep SBS-canonical key names in the Secret (`username`, `database`) while ALSO projecting the spellings libpq / JDBC / `pg` npm package / sequelize / prisma expect (`DB_USER`, `DB_NAME`).

For the demo project: `DB_USERNAME=app` AND `DB_USER=app` both land in the pod, both pointing at the same Secret key `username`. App code that uses `process.env.DB_USER` works without modifying the Secret shape.

### 2. `required: true` rejects empty string

Today the helper accepted empty string as a "set" value because `_dig` returned `""` not the missing-sentinel. Most SQL clients treat empty password as falsy and silently fall back to `PGPASSWORD` env var (typically undefined), producing confusing runtime errors. Now the helper fails at template time:

```
Error: services[binding=db].auth.user.password is required for type=postgresql but is empty (""). Set a non-empty value before tilt up — most clients (pg, mysql, redis) treat an empty password as missing and silently fall back, producing a confusing runtime error rather than a clear template-time one.
```

### 3. `validateConsistency`: `<chart>.enabled` must be true for local services

Demo footgun: a dev sees `services[].type=postgresql` + `postgresql.enabled: true` in their values.yaml and reads it as redundancy. They remove the flag. Helm template still renders the binding-secret. Pod fails at runtime with `getaddrinfo ENOTFOUND <release>-postgresql` — completely opaque.

The flag is required because Helm dependency `condition` is evaluated at dep-resolution time, BEFORE `_helpers.tpl` runs — we can't auto-derive it. New check fails loud:

```
Error: services[binding=db].type=postgresql, provisioning=local — but suse-library.postgresql.enabled is not true. The Helm dep gates the sub-chart on `condition: postgresql.enabled` ... Set:

    suse-library:
      postgresql:
        enabled: true
```

Hiding the flag (so it doesn't even appear in `values.yaml`) is followup work — tracked in #64.

## Test

- New `library-chart/tests/env-aliases/` smoke test asserts both `DB_USERNAME` and `DB_USER` project on the rendered Deployment, both referencing `key: username`.
- Existing fixtures (`passthrough-collision/`, `provisioning/`, `auto-ingress-ui/`) updated to set `<chart>.enabled: true` — production-correct config; previously they relied on the silent rendering path that this PR now rejects.
- Schema validator (`dsl-mappings-schema/check.py`) extended to validate `env_aliases` shape (rejects no-op aliases that re-spell the key, aliases on `skip_env` entries, non-string aliases).

All test suites pass: `passthrough-collision` 9/9, `provisioning` 8/8, `auto-ingress-ui` 8/8, `env-aliases` 8/8, schema valid, catalog-consistency clean.

## Versions

`library-chart` 0.11.0 → 0.11.1 (additive feature). `rda-bundle.yaml` and `templates/web-nodejs/chart/Chart.yaml` dep pins bumped to match.

## Companion follow-up issues

- idefxH/rda-cli#59 — `rda doctor`: detect orphan / drifted PVCs that survive password changes
- idefxH/rda-opinion-bundle-example#63 — `validateConsistency`: detect binding-secret auth vs deployed PVC drift
- idefxH/rda-cli#60 — `add-service`: scaffold persistence-off by default for stateful charts
- idefxH/rda-opinion-bundle-example#64 — hide `<chart>.enabled` from `values.yaml` (move to `chart/values.generated.yaml`)

## Discovered

Live demo Apr 30, 2026. The user's postgres binding kept failing in cascading ways: (a) `DB_USER` not set → user "demo" auth fail, (b) empty password → `client password must be a string`, (c) PVC retention drift → `password authentication failed for user "app"`, (d) flag removal → `getaddrinfo ENOTFOUND payments-postgresql`. (a), (b), (d) are now caught at template time with actionable messages; (c) is tracked in the companion issues.
