### PR TITLE
feat(library): auth-seed annotation + validateConsistency PVC drift check (0.11.2)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.1
+version: 0.11.2
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -25,6 +25,17 @@
 #     port: <int>
 #   values_mapping:            # DSL path → chart values path
 #     <dsl-path>: <values-path>
+#   auth_seed_paths:           # OPTIONAL list of DSL paths whose values are
+#     - <dsl-path>             # baked into the chart's PVC on first init
+#                              # (typically the user/password/database used
+#                              # by the chart's init container). Drives the
+#                              # rda.suse.com/auth-seed annotation on the
+#                              # binding-secret + the validateConsistency
+#                              # drift check. Stateful charts (postgres,
+#                              # mariadb, mongo, redis-with-persistence)
+#                              # declare this; stateless ones (grafana,
+#                              # prometheus) leave it absent. See
+#                              # idefxH/rda-opinion-bundle-example#63.
 #   binding_secret:            # ordered list, projects to <release>-<binding>-binding
 #     - key: <name>
 #       <one of: literal | template | from_dsl>
@@ -35,6 +46,11 @@
 #                              # not project it as <BINDING>_<KEY> (used for
 #                              # metadata keys like type / provider that the
 #                              # app shouldn't see as env vars)
+#       env_aliases:           # OPTIONAL list of strings; emits additional
+#         - <name>             # env vars referencing the same Secret key,
+#                              # e.g. ['user'] on the username key projects
+#                              # both DB_USERNAME (canonical) and DB_USER
+#                              # (env-var convention).
 #
 # The CATALOG.md doc in rda-devx-catalog should stay aligned with this file.
 # Phase 2.5 will add a CI check that asserts CATALOG.md mentions every chart
@@ -63,6 +79,17 @@ charts:
           resources.requests.memory: postgresql.primary.resources.requests.memory
           resources.limits.cpu: postgresql.primary.resources.limits.cpu
           resources.limits.memory: postgresql.primary.resources.limits.memory
+        # AppCo postgres init only runs once on empty PGDATA. Once these
+        # values are baked into the volume, subsequent re-deploys keep the
+        # ORIGINAL credentials/database — env-var changes are silently
+        # ignored. Listing these paths drives the auth-seed annotation +
+        # the template-time drift check that fails loud with the nuke
+        # recipe when the dev edits one of them after first deploy.
+        auth_seed_paths:
+          - auth.user.name
+          - auth.user.password
+          - auth.user.database
+          - auth.admin.password
         binding_secret:
           - {key: type, literal: postgresql, skip_env: true}
           - {key: provider, literal: rda-appco, skip_env: true}
@@ -95,6 +122,13 @@ charts:
           resources.requests.memory: redis.master.resources.requests.memory
           resources.limits.cpu: redis.master.resources.limits.cpu
           resources.limits.memory: redis.master.resources.limits.memory
+        # Redis password lives in the AOF / RDB snapshot once persistence
+        # is on — flipping it after first init requires a PVC reset.
+        # When persistence is off (default for redis), the auth seed
+        # check still fires but is informational: the lookup finds no
+        # PVC, the helper short-circuits with no warning.
+        auth_seed_paths:
+          - auth.password
         binding_secret:
           - {key: type, literal: redis, skip_env: true}
           - {key: provider, literal: rda-appco, skip_env: true}

--- a/library-chart/templates/_helpers.tpl
+++ b/library-chart/templates/_helpers.tpl
@@ -140,6 +140,39 @@ name, or empty dict. Used by `rda explain` and the dsl helper unit tests.
 {{- end -}}
 
 {{/*
+suse-library.dsl.authSeed — compute a deterministic short hash of the
+auth fields that a stateful chart bakes into its PVC at first init.
+Used both:
+  - as the value of the rda.suse.com/auth-seed annotation on the
+    binding-secret (so we know what was baked the first time)
+  - as the comparison input in validateConsistency's drift check
+    (to detect that the dev edited an auth field after first deploy
+    and would need a PVC reset).
+
+Args (dict): svc, mapping (the version-resolved chart entry from
+dsl-mappings.yaml).
+
+Returns: 16-hex-char short SHA256 of the joined "path=value\n" lines.
+Empty when the chart has no auth_seed_paths declared (stateless types
+like grafana). Empty seed = no annotation emitted = no drift check.
+*/}}
+{{- define "suse-library.dsl.authSeed" -}}
+{{- $svc := .svc -}}
+{{- $mapping := .mapping -}}
+{{- $paths := index $mapping "auth_seed_paths" | default list -}}
+{{- if gt (len $paths) 0 -}}
+{{- $parts := list -}}
+{{- range $path := $paths -}}
+  {{- $keys := splitList "." $path -}}
+  {{- $val := include "suse-library.dsl._dig" (dict "obj" $svc "keys" $keys "sentinel" "_RDA_NONE_") -}}
+  {{- if eq $val "_RDA_NONE_" -}}{{- $val = "" -}}{{- end -}}
+  {{- $parts = append $parts (printf "%s=%s" $path $val) -}}
+{{- end -}}
+{{- join "\n" $parts | sha256sum | trunc 16 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 suse-library.dsl.validateConsistency — sanity checks on services[]. Phase 1
 checks:
   - every entry has a non-empty `binding`
@@ -153,6 +186,13 @@ checks:
     they're out of sync. `rda add-service` writes both halves; this
     check catches the case where someone removes <chart>.enabled
     manually thinking it's redundant with the DSL entry.
+  - for stateful types (auth_seed_paths declared): if a binding-secret
+    already exists in the cluster (= chart was deployed before), its
+    rda.suse.com/auth-seed annotation must match the freshly-computed
+    seed. Mismatch means the dev edited an auth field after first init
+    of the PVC; chart sub-init won't re-run, the new credentials don't
+    take, runtime fails with confusing auth errors. Fail loud at
+    template time with the nuke recipe. Closes #63.
 */}}
 {{- define "suse-library.dsl.validateConsistency" -}}
 {{- $mappings := include "suse-library.dsl.loadMappings" . | fromJson -}}
@@ -180,6 +220,31 @@ checks:
   {{- if not (eq (kindOf $chartBlock) "map") -}}{{- $chartBlock = dict -}}{{- end -}}
   {{- if not (eq (index $chartBlock "enabled" | default false) true) -}}
   {{- fail (printf "services[binding=%s].type=%s, provisioning=local — but suse-library.%s.enabled is not true. The Helm dep gates the sub-chart on `condition: %s.enabled`, and condition is evaluated at dep resolution time, so the DSL entry alone can't trigger the dep. Set:\n\n    suse-library:\n      %s:\n        enabled: true\n\n(Or run `rda add-service` which writes both halves automatically.) See rda-docs/concepts/dsl.md#why-the-enabled-flag-is-not-redundant." $svc.binding $svc.type $svc.type $svc.type $svc.type) -}}
+  {{- end -}}
+  {{- /* Auth-seed drift check (#63). Fires only when:
+           1. the chart declares auth_seed_paths in dsl-mappings.yaml
+           2. an existing binding-secret carries an auth-seed annotation
+              (lookup returns non-nil — i.e. we're at apply time, not at
+               helm template --dry-run, AND the chart was deployed before)
+         First-deploy: lookup returns nil → skip silently. CI dry-runs:
+         lookup returns nil → skip silently. Re-deploy after auth edit:
+         seed mismatch → fail loud with nuke recipe. */ -}}
+  {{- $vEntry := include "suse-library.dsl.resolveMapping" (dict "chart" $svc.type "root" $) | fromJson -}}
+  {{- $authPaths := index $vEntry "auth_seed_paths" | default list -}}
+  {{- if gt (len $authPaths) 0 -}}
+    {{- $secretName := printf "%s-%s-binding" $.Release.Name $svc.binding -}}
+    {{- $namespace := $.Release.Namespace -}}
+    {{- $existing := lookup "v1" "Secret" $namespace $secretName -}}
+    {{- if $existing -}}
+      {{- $annotations := $existing.metadata.annotations | default dict -}}
+      {{- $existingSeed := index $annotations "rda.suse.com/auth-seed" | default "" -}}
+      {{- if ne $existingSeed "" -}}
+        {{- $currentSeed := include "suse-library.dsl.authSeed" (dict "svc" $svc "mapping" $vEntry) -}}
+        {{- if ne $existingSeed $currentSeed -}}
+        {{- fail (printf "services[binding=%s] auth has changed since this chart's PVC was first initialised (seed %s → %s). %s only initialises its credentials once, on first start of an empty PGDATA. Subsequent re-deploys keep the ORIGINAL credentials/database baked into the volume — your DSL edit is silently ignored, and the runtime fails with confusing auth errors.\n\nTo pick up the new auth values, nuke the volume:\n\n    tilt down\n    kubectl delete pvc -l app.kubernetes.io/instance=%s\n    tilt up\n\nIf you didn't mean to change the auth, revert your DSL edit (re-render against git: rda render --check).\n\nSee idefxH/rda-opinion-bundle-example#63." $svc.binding $existingSeed $currentSeed $svc.type $.Release.Name) -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -390,6 +455,21 @@ metadata:
     # to their values.yaml without having to dive into helper code.
     rda.suse.com/source: "services[binding={{ $svc.binding }}].type={{ $svc.type }}.provisioning={{ $provisioning }}"
     rda.suse.com/helper: "suse-library.dsl.bindingSecretFrom"
+    {{- /* Auth-seed annotation (#63). Stamps the secret with a hash of
+           the auth fields the chart's PVC bakes on first init. On
+           re-deploy, validateConsistency reads this annotation back via
+           lookup and compares with the freshly-computed seed. Mismatch
+           = the dev edited an auth field after first init = PVC reset
+           required. Empty when the chart is stateless (no auth_seed_paths
+           in dsl-mappings.yaml — grafana, prometheus). Only emitted for
+           provisioning=local: shared/external bindings don't have a PVC
+           to drift against. */ -}}
+    {{- if eq $provisioning "local" -}}
+    {{- $authSeed := include "suse-library.dsl.authSeed" (dict "svc" $svc "mapping" $mapping) -}}
+    {{- if ne $authSeed "" }}
+    rda.suse.com/auth-seed: {{ $authSeed | quote }}
+    {{- end -}}
+    {{- end }}
 type: Opaque
 stringData:
 {{- range $bsEntry := index $mapping "binding_secret" }}

--- a/library-chart/tests/auth-seed/01-postgres-emits-auth-seed.values.yaml
+++ b/library-chart/tests/auth-seed/01-postgres-emits-auth-seed.values.yaml
@@ -1,0 +1,15 @@
+# Smoke test: postgres binding's secret should carry an auth-seed annotation
+# whose hash is deterministic (same input = same hash).
+services:
+  - binding: db
+    type: postgresql
+    auth:
+      admin: { password: "admin-pw" }
+      user:
+        name: app
+        password: "app-pw"
+        database: demo
+    persistence: { enabled: false }
+
+postgresql:
+  enabled: true

--- a/library-chart/tests/auth-seed/02-grafana-no-auth-seed.values.yaml
+++ b/library-chart/tests/auth-seed/02-grafana-no-auth-seed.values.yaml
@@ -1,0 +1,9 @@
+# Stateless chart — no auth_seed_paths in dsl-mappings.yaml — no annotation.
+services:
+  - binding: dashboards
+    type: grafana
+    auth:
+      admin: { name: admin, password: "admin-pw" }
+
+grafana:
+  enabled: true

--- a/library-chart/tests/auth-seed/03-shared-no-auth-seed.values.yaml
+++ b/library-chart/tests/auth-seed/03-shared-no-auth-seed.values.yaml
@@ -1,0 +1,11 @@
+# Shared services don't deploy a sub-chart, so no PVC drift to track.
+services:
+  - binding: db
+    type: postgresql
+    provisioning: shared
+    auth:
+      user: { name: app, password: "x", database: y }
+
+defaults:
+  shared_services:
+    postgresql: { host: pg.platform, port: 5432, scheme: postgres }

--- a/library-chart/tests/auth-seed/run.sh
+++ b/library-chart/tests/auth-seed/run.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Smoke tests for auth-seed annotation (#63):
+#   1. postgres-with-auth_seed_paths emits the annotation
+#   2. grafana (stateless, no auth_seed_paths) does NOT emit
+#   3. shared provisioning does NOT emit (no PVC to drift against)
+#
+# We don't test the validateConsistency drift check here because it
+# depends on Helm's `lookup` returning a non-nil resource, which only
+# happens at apply time (not at helm template). The drift check is
+# documented in the helper and exercised end-to-end in the demo flow.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHART_SRC="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$CHART_SRC" "$WORK/library-chart"
+python3 -c "
+import re
+p = '$WORK/library-chart/Chart.yaml'
+s = open(p).read()
+s = re.sub(r'\ndependencies:.*', '\n', s, flags=re.DOTALL)
+open(p, 'w').write(s)
+"
+
+CHART="$WORK/library-chart"
+PASS=0
+FAIL=0
+
+# 1. postgres emits the annotation
+F1="$SCRIPT_DIR/01-postgres-emits-auth-seed.values.yaml"
+OUT1="$(helm template demo "$CHART" -f "$F1" 2>&1)"
+if echo "$OUT1" | grep -q "rda.suse.com/auth-seed:"; then
+    SEED="$(echo "$OUT1" | grep "rda.suse.com/auth-seed:" | head -1 | sed 's/.*"\(.*\)".*/\1/')"
+    if [ -z "$SEED" ] || [ "${#SEED}" -ne 16 ]; then
+        echo "✗ 01: auth-seed present but value is not a 16-char hash: $SEED"
+        FAIL=$((FAIL + 1))
+    else
+        echo "✓ 01: postgres emits rda.suse.com/auth-seed=$SEED (16-char hash)"
+        PASS=$((PASS + 1))
+    fi
+else
+    echo "✗ 01: postgres should emit rda.suse.com/auth-seed annotation"
+    echo "$OUT1" | grep -A 2 "annotations:" | head -10
+    FAIL=$((FAIL + 1))
+fi
+
+# 1b. Same input = same hash (determinism)
+OUT1b="$(helm template demo "$CHART" -f "$F1" 2>&1)"
+SEED1b="$(echo "$OUT1b" | grep "rda.suse.com/auth-seed:" | head -1 | sed 's/.*"\(.*\)".*/\1/')"
+if [ "$SEED" = "$SEED1b" ]; then
+    echo "✓ 01b: auth-seed is deterministic across runs ($SEED)"
+    PASS=$((PASS + 1))
+else
+    echo "✗ 01b: auth-seed is non-deterministic: $SEED vs $SEED1b"
+    FAIL=$((FAIL + 1))
+fi
+
+# 1c. Different password = different hash
+TMPVAL="$(mktemp)"
+sed 's/app-pw/different-pw/' "$F1" > "$TMPVAL"
+OUT1c="$(helm template demo "$CHART" -f "$TMPVAL" 2>&1)"
+SEED1c="$(echo "$OUT1c" | grep "rda.suse.com/auth-seed:" | head -1 | sed 's/.*"\(.*\)".*/\1/')"
+if [ -n "$SEED1c" ] && [ "$SEED" != "$SEED1c" ]; then
+    echo "✓ 01c: auth-seed changes when password changes ($SEED -> $SEED1c)"
+    PASS=$((PASS + 1))
+else
+    echo "✗ 01c: auth-seed should change when password changes (got '$SEED' and '$SEED1c')"
+    FAIL=$((FAIL + 1))
+fi
+rm -f "$TMPVAL"
+
+# 2. grafana (stateless) does NOT emit
+F2="$SCRIPT_DIR/02-grafana-no-auth-seed.values.yaml"
+OUT2="$(helm template demo "$CHART" -f "$F2" 2>&1)"
+if echo "$OUT2" | grep -q "rda.suse.com/auth-seed:"; then
+    echo "✗ 02: grafana should NOT emit auth-seed (no auth_seed_paths in dsl-mappings)"
+    FAIL=$((FAIL + 1))
+else
+    echo "✓ 02: grafana correctly skips auth-seed annotation"
+    PASS=$((PASS + 1))
+fi
+
+# 3. shared provisioning does NOT emit
+F3="$SCRIPT_DIR/03-shared-no-auth-seed.values.yaml"
+OUT3="$(helm template demo "$CHART" -f "$F3" 2>&1)"
+if echo "$OUT3" | grep -q "rda.suse.com/auth-seed:"; then
+    echo "✗ 03: shared provisioning should NOT emit auth-seed (no PVC to drift against)"
+    FAIL=$((FAIL + 1))
+else
+    echo "✓ 03: shared provisioning correctly skips auth-seed annotation"
+    PASS=$((PASS + 1))
+fi
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ]

--- a/library-chart/tests/dsl-mappings-schema/check.py
+++ b/library-chart/tests/dsl-mappings-schema/check.py
@@ -191,6 +191,39 @@ def check_version(errors, chart, vidx, ver):
         check_values_mapping(errors, chart, vidx, ver["values_mapping"])
     if "binding_secret" in ver:
         check_binding_secret(errors, chart, vidx, ver["binding_secret"])
+    if "auth_seed_paths" in ver:
+        check_auth_seed_paths(errors, chart, vidx, ver["auth_seed_paths"], ver.get("values_mapping", {}))
+
+
+def check_auth_seed_paths(errors, chart, vidx, paths, values_mapping):
+    """Validate auth_seed_paths: list of non-empty strings, no duplicates,
+    each must be either a known DSL path (present in values_mapping keys)
+    or a documented exception. The cross-check with values_mapping prevents
+    typos that would silently produce a constant hash (a path the helper
+    can't dig in svc would resolve to "" and the seed would be deterministic
+    but wrong)."""
+    base = "charts.%s.versions[%d].auth_seed_paths" % (chart, vidx)
+    if not isinstance(paths, list):
+        err(errors, base, "must be a list of DSL path strings, got %s" % type(paths).__name__)
+        return
+    seen = set()
+    for i, p in enumerate(paths):
+        path_at = "%s[%d]" % (base, i)
+        if not isinstance(p, str) or not p:
+            err(errors, path_at, "must be a non-empty string")
+            continue
+        if p in seen:
+            err(errors, path_at, "duplicate path %r" % p)
+        seen.add(p)
+        # Require each auth_seed_path to be in values_mapping. Otherwise
+        # the helper would dig a key that's never set on the service entry,
+        # silently producing a hash of empty strings.
+        if p not in values_mapping:
+            err(errors, path_at,
+                "path %r is not in values_mapping; the helper would dig it as missing "
+                "and produce a meaningless seed. Either declare the path in values_mapping "
+                "(if the field is meant to project to the sub-chart) or remove it from "
+                "auth_seed_paths." % p)
 
 
 def check_chart(errors, chart, body):

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.1
+  version: 0.11.2
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.11.1
+    version: 0.11.2
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
## What

Closes **#63**. Detect binding-secret auth vs deployed PVC drift at template time, fail loud with the nuke recipe.

## The problem (recap from #63)

When a developer edits `services[].auth.user.password` (or similar) AFTER the chart was deployed once, the AppCo postgres init **does not** pick up the new value. Postgres only runs `initdb` on an empty PGDATA — subsequent restarts honour the env vars but the on-disk auth state is unchanged. Net effect: app pod tries to connect with the new credentials, postgres rejects them with `Role "app" does not exist` or `password authentication failed`. The dev sees a confusing runtime error and has no way to know they hit PVC drift.

This was the third cascading error in the Apr 30 demo; the `rda doctor` safety net is **idefxH/rda-cli#59** (filed separately).

## Solution — five additive pieces

### 1. `dsl-mappings.yaml` gets `auth_seed_paths`

New OPTIONAL field per stateful chart entry. Lists the DSL paths whose values are baked into the PVC at first init:

```yaml
postgresql:
  versions:
    - auth_seed_paths:
        - auth.user.name
        - auth.user.password
        - auth.user.database
        - auth.admin.password

redis:
  versions:
    - auth_seed_paths:
        - auth.password
```

Stateless charts (grafana) leave it absent. No PVC, no drift.

### 2. Helper `suse-library.dsl.authSeed`

Computes a deterministic 16-char SHA256 from those paths' values for a given service entry. Empty when `auth_seed_paths` is absent.

### 3. `binding-secret.yaml` emits `rda.suse.com/auth-seed`

Annotation on every binding-secret for stateful, `provisioning: local` bindings:

```yaml
metadata:
  annotations:
    rda.suse.com/source: "..."
    rda.suse.com/helper: "suse-library.dsl.bindingSecretFrom"
    rda.suse.com/auth-seed: "eb20a8c6c9d32c0e"
```

### 4. `validateConsistency` drift check

For each `services[]` entry of a stateful type:

```
lookup the existing binding-secret in the cluster
if found AND its auth-seed annotation differs from the freshly-computed seed
  → fail loud with the nuke recipe
```

- **First deploy**: lookup returns nil → no check, just emit the annotation.
- **`helm template --dry-run`**: lookup returns nil → no check.
- **Re-deploy with same auth**: seeds match → no failure.
- **Re-deploy with edited auth**: seed mismatch → fail loud:

```
Error: services[binding=db] auth has changed since this chart's PVC
was first initialised (seed eb20a8c6c9d32c0e → b261b2a272353bd2).
postgresql only initialises its credentials once, on first start of
an empty PGDATA. Subsequent re-deploys keep the ORIGINAL credentials
baked into the volume — your DSL edit is silently ignored, and the
runtime fails with confusing auth errors.

To pick up the new auth values, nuke the volume:

    tilt down
    kubectl delete pvc -l app.kubernetes.io/instance=<release>
    tilt up

If you didn't mean to change the auth, revert your DSL edit.
```

### 5. Schema validator + tests

- `check.py` validates `auth_seed_paths`: list of non-empty strings, no duplicates, each must be in `values_mapping` (typo guard — a path the helper can't dig would silently produce a constant hash regardless of value).
- New `library-chart/tests/auth-seed/` smoke tests:
  - postgres emits annotation, deterministic across runs
  - changing password changes the hash
  - grafana (stateless) does NOT emit
  - shared provisioning does NOT emit

## Test

- `passthrough-collision`: 9/9 ✅
- `provisioning`: 8/8 ✅
- `auto-ingress-ui`: 8/8 ✅
- `env-aliases`: 8/8 ✅
- `auth-seed`: 5/5 ✅ (new)
- `dsl-mappings-schema`: clean ✅

The drift check itself isn't unit-testable via `helm template` (`lookup` only returns non-nil at apply time). It's exercised end-to-end in the demo flow.

## Versions

`library-chart` 0.11.1 → 0.11.2 (additive feature). `rda-bundle.yaml` and `templates/web-nodejs/chart/Chart.yaml` dep pins bumped.

## Companion

- **idefxH/rda-cli#59** — `rda doctor` PVC-orphan detection (the safety net for when the chart was deployed by other means or `lookup` returned stale data).
