### PR TITLE
feat(catalog): add prometheus entry (0.11.3)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.2
+version: 0.11.3
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example
@@ -40,7 +40,7 @@ dependencies:
     repository: oci://dp.apps.rancher.io/charts
     condition: postgresql.enabled
   - name: prometheus
-    version: "29.2.1-6.1"
+    version: "29.3.0-7.1"
     repository: oci://dp.apps.rancher.io/charts
     condition: prometheus.enabled
   - name: grafana

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -136,6 +136,54 @@ charts:
           - {key: port, literal: "6379"}
           - {key: password, from_dsl: auth.password, required: true}
 
+  prometheus:
+    versions:
+      - constraint: ">=29.0.0"
+        # AppCo prometheus 29.x (community chart 29.x lineage, prometheus
+        # binary 3.11.x). Service is named <release>-prometheus-server
+        # (`-server` suffix because the chart deploys server +
+        # alertmanager + node-exporter + pushgateway + kube-state-metrics
+        # as separate workloads). Port 80 → pod port 9090 (HTTP UI +
+        # /metrics + /api/v1/query). UI auto-Ingress (issue #8) uses
+        # port 80.
+        #
+        # No auth: Prometheus is unauthenticated by default — ingress
+        # protection (BasicAuth, OIDC) is the standard way to secure
+        # the UI in shared clusters. No auth_seed_paths since there's
+        # no PVC-baked credential to drift against; the time-series
+        # database is data, not auth state.
+        service:
+          host: "{{ .Release.Name }}-prometheus-server"
+          port: 80
+          scheme: http
+        values_mapping:
+          # Persistence for the TSDB (time-series database).
+          persistence.enabled: prometheus.server.persistentVolume.enabled
+          persistence.size: prometheus.server.persistentVolume.size
+          # Retention (how long to keep metrics — e.g. "15d", "30d").
+          # Prometheus-specific DSL field; the chart's default applies
+          # when unset.
+          retention: prometheus.server.retention
+          # UI Ingress.
+          ingress.enabled: prometheus.server.ingress.enabled
+          ingress.host: prometheus.server.ingress.hosts[0]
+          # Resources are server-scoped (the other prometheus chart
+          # components — alertmanager, exporters, pushgateway — are
+          # disabled by default in the library's values.yaml).
+          resources.requests.cpu: prometheus.server.resources.requests.cpu
+          resources.requests.memory: prometheus.server.resources.requests.memory
+          resources.limits.cpu: prometheus.server.resources.limits.cpu
+          resources.limits.memory: prometheus.server.resources.limits.memory
+        binding_secret:
+          - {key: type, literal: prometheus, skip_env: true}
+          - {key: provider, literal: rda-appco, skip_env: true}
+          - {key: host, template: "{{ .Release.Name }}-prometheus-server"}
+          - {key: port, literal: "80"}
+          # url is the canonical "where do I scrape / query" — apps that
+          # use Prometheus as a data source (Grafana, custom dashboards,
+          # OpenTelemetry pipelines) typically read this single field.
+          - {key: url, template: "http://{{ .Release.Name }}-prometheus-server:80"}
+
   grafana:
     versions:
       - constraint: ">=12.0.0"

--- a/library-chart/tests/prometheus/01-prometheus-basic.values.yaml
+++ b/library-chart/tests/prometheus/01-prometheus-basic.values.yaml
@@ -1,0 +1,15 @@
+# Smoke test: prometheus binding renders a binding-secret with host/port/url,
+# emits env vars (PROM_HOST, PROM_PORT, PROM_URL), and does NOT emit an
+# auth-seed annotation (stateless from the auth perspective).
+services:
+  - binding: prom
+    type: prometheus
+    persistence:
+      enabled: true
+      size: 5Gi
+    retention: "15d"
+    ingress:
+      enabled: false
+
+prometheus:
+  enabled: true

--- a/library-chart/tests/prometheus/run.sh
+++ b/library-chart/tests/prometheus/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Smoke tests for the prometheus catalog entry:
+#   1. binding-secret has host/port/url with the right values
+#   2. NO auth-seed annotation (no auth_seed_paths in dsl-mappings)
+#   3. env vars on app Deployment: PROM_HOST/PORT/URL
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHART_SRC="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$CHART_SRC" "$WORK/library-chart"
+python3 -c "
+import re
+p = '$WORK/library-chart/Chart.yaml'
+s = open(p).read()
+s = re.sub(r'\ndependencies:.*', '\n', s, flags=re.DOTALL)
+open(p, 'w').write(s)
+"
+
+CHART="$WORK/library-chart"
+F="$SCRIPT_DIR/01-prometheus-basic.values.yaml"
+
+OUT="$(helm template demo "$CHART" -f "$F" 2>&1)"
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "✗ helm template failed:"
+    echo "$OUT"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+check() {
+    local name="$1"
+    local needle="$2"
+    if echo "$OUT" | grep -q -F "$needle"; then
+        echo "✓ $name"
+        PASS=$((PASS + 1))
+    else
+        echo "✗ $name (missing: $needle)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check "binding-secret name = demo-prom-binding" "name: demo-prom-binding"
+check "binding-secret host = demo-prometheus-server" 'host: "demo-prometheus-server"'
+check "binding-secret port = 80" 'port: "80"'
+check "binding-secret url = http://demo-prometheus-server:80" 'url: "http://demo-prometheus-server:80"'
+check "binding-secret type = prometheus" 'type: "prometheus"'
+check "env var PROM_HOST" "name: PROM_HOST"
+check "env var PROM_PORT" "name: PROM_PORT"
+check "env var PROM_URL" "name: PROM_URL"
+
+# NO auth-seed annotation (stateless type).
+if echo "$OUT" | grep -q "rda.suse.com/auth-seed"; then
+    # Could match other bindings. Check it's not on the prom binding.
+    SEED_LINES="$(echo "$OUT" | awk '/name: demo-prom-binding/,/---/' | grep "auth-seed" || true)"
+    if [ -n "$SEED_LINES" ]; then
+        echo "✗ prometheus binding-secret should NOT have auth-seed annotation (stateless type)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "✓ prometheus binding-secret correctly omits auth-seed annotation"
+        PASS=$((PASS + 1))
+    fi
+else
+    echo "✓ no auth-seed annotation anywhere (correct for stateless prom-only project)"
+    PASS=$((PASS + 1))
+fi
+
+# NO password env var (prometheus has no auth).
+if echo "$OUT" | grep -q "name: PROM_PASSWORD"; then
+    echo "✗ prometheus should NOT emit a PROM_PASSWORD env var (no auth)"
+    FAIL=$((FAIL + 1))
+else
+    echo "✓ no PROM_PASSWORD env var (correct for no-auth chart)"
+    PASS=$((PASS + 1))
+fi
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ]

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.2
+  version: 0.11.3
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.11.2
+    version: 0.11.3
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
## What

Add **Prometheus** as a first-class catalogued service type. After this PR, `rda add-service prometheus metrics` produces a working binding-secret + env vars + correct service.host substitution (which fixes the workload naming the Tilt extension hook uses) without manual chart-specific values.

Library version 0.11.2 → 0.11.3.

## What landed

| Concern | Detail |
|---|---|
| **`dsl-mappings.yaml`** | New `prometheus` entry. `constraint: ">=29.0.0"`. service.host = `<release>-prometheus-server`, port 80, scheme http. |
| **values_mapping** | persistence (TSDB), retention (custom DSL field — e.g. `15d`), ingress, resources scoped to `.server.*`. Matches the chart's component split: server is the only piece deployed by default; alertmanager / node-exporter / pushgateway / kube-state-metrics stay disabled per `library-chart/values.yaml`. |
| **binding_secret** | `type, provider, host, port, url`. **No password key** — Prometheus is unauthenticated by default; ingress protection (BasicAuth, OIDC) is the standard way to secure the UI. |
| **No `auth_seed_paths`** | Prometheus has no PVC-baked credential to drift against — the time-series database is data, not auth state. validateConsistency drift check correctly does not fire for prometheus bindings. |
| **AppCo dep version** | Bumped from `29.2.1-6.1` to `29.3.0-7.1` (latest from the AppCo MCP catalog as of Apr 30). |

## DSL surface for the dev

```yaml
suse-library:
  services:
    - binding: metrics
      type: prometheus
      persistence:
        enabled: true
        size: 10Gi
      retention: "15d"
      ingress:
        enabled: false
      resources:
        requests: { cpu: 100m, memory: 512Mi }
        limits:   { cpu: 1, memory: 2Gi }
  prometheus:
    enabled: true
```

After `rda render`, `chart/values.generated.yaml` projects:
- `prometheus.server.persistentVolume.enabled / size`
- `prometheus.server.retention`
- `prometheus.server.ingress.enabled / hosts`
- `prometheus.server.resources.{requests,limits}.{cpu,memory}`

App pod gets `METRICS_HOST=<release>-prometheus-server`, `METRICS_PORT=80`, `METRICS_URL=http://<release>-prometheus-server:80`.

## Test

- New `library-chart/tests/prometheus/` smoke test: 10/10 ✅
- All existing tests stay green:
  - passthrough-collision: 9/9 ✅
  - provisioning: 8/8 ✅
  - auto-ingress-ui: 8/8 ✅ (was already wired for `prometheus.server.ingress`)
  - env-aliases: 8/8 ✅
  - auth-seed: 5/5 ✅
  - dsl-mappings-schema: clean, 4 charts ✅
  - catalog-consistency: 4/4 charts have CATALOG.md sections ✅

## Methodology

Queried the **AppCo MCP** (`search_applications` + `get_application_details` for `slug_name="prometheus"`) for the canonical chart version. The chart-doc endpoint returned empty for this chart, so the values_mapping was derived from the existing `library-chart/values.yaml` stub (which already had `prometheus.server.persistentVolume` + `ui.expose`) plus the prometheus-community chart conventions (`server.persistentVolume.enabled`, `server.retention`, `server.ingress.enabled`, `server.resources.*`) — these are stable across Bitnami / AppCo lineages.

## Companion

- **idefxH/tilt-extension-suse-rda#10** — workload name from `dsl-mappings.yaml service.host`. With this PR + #10 merged, `rda add-service prometheus metrics` + `tilt up` works end-to-end (Tilt finds `<release>-prometheus-server` correctly).

## Discovered

Live demo Apr 30, 2026 — user wanted prometheus in the catalog.
