### PR TITLE
fix(library): declare redis as Helm dep + align dsl-mappings constraint (0.11.4)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.3
+version: 0.11.4
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example
@@ -47,3 +47,7 @@ dependencies:
     version: "12.2.1-8.1"
     repository: oci://dp.apps.rancher.io/charts
     condition: grafana.enabled
+  - name: redis
+    version: "2.6.1-3.1"
+    repository: oci://dp.apps.rancher.io/charts
+    condition: redis.enabled

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -105,11 +105,16 @@ charts:
 
   redis:
     versions:
-      - constraint: ">=21.0.0"
-        # AppCo redis 21.x (Bitnami 17.x lineage). Service has -master suffix
-        # because the chart deploys a primary/replicas split. The DSL
-        # persistence.enabled / metrics.enabled paths lift onto master.* under
-        # the hood — see values_mapping.
+      - constraint: ">=2.0.0 <3.0.0"
+        # AppCo redis 2.x (chart packaging — redis binary 8.x lineage).
+        # Note: the constraint uses the AppCo helm chart version, not
+        # the redis container version. AppCo repackages as 2.x; if you
+        # see "21.x" referenced anywhere it's the upstream Bitnami
+        # convention and doesn't apply here.
+        # Service has -master suffix because the chart deploys a
+        # primary/replicas split. The DSL persistence.enabled /
+        # metrics.enabled paths lift onto master.* under the hood —
+        # see values_mapping.
         service:
           host: "{{ .Release.Name }}-redis-master"
           port: 6379

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.3
+  version: 0.11.4
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.11.3
+    version: 0.11.4
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
## What

`library-chart/Chart.yaml` was missing a `redis` Helm dependency declaration even though redis is catalogued in `dsl-mappings.yaml`. The DSL helper renders binding-secrets + projects env vars correctly, but `helm dep update` never pulls `redis-X.tgz` into `chart/charts/suse-library/charts/`, so the AppCo redis sub-chart never deploys.

Result: `rda add-service redis cache` + `tilt up`:
- ✅ binding-secret `payments-cache-binding` rendered
- ✅ env vars `CACHE_HOST=payments-redis-master, CACHE_PORT, CACHE_PASSWORD` projected
- ❌ but `payments-redis-master` Service/StatefulSet doesn't exist (sub-chart not pulled)
- ❌ Tilt hook registers `k8s_resource("payments-redis-master")` → "unknown resource"

Fix: declare the missing dep.

## Methodology

Queried the **AppCo MCP** (`get_application_details` for `slug_name="redis"`) for the latest helm chart version: `oci://dp.apps.rancher.io/charts/redis:2.6.1-3.1` (redis container 8.6.1).

Also noticed and fixed a bug in `dsl-mappings.yaml`: the redis constraint was `>=21.0.0` (the upstream Bitnami chart's version line) but AppCo repackages as `2.x`. The helper's `resolveMapping` was falling back to the first versions[] entry by accident — masking the issue. Constraint now aligned to `>=2.0.0 <3.0.0`. Comment updated to clarify AppCo packaging vs Bitnami lineage.

## What landed

| File | Change |
|---|---|
| `library-chart/Chart.yaml` | New `redis` dep entry: `version: 2.6.1-3.1`, `condition: redis.enabled`, repo `oci://dp.apps.rancher.io/charts`. |
| `library-chart/dsl-mappings.yaml` | redis constraint `">=21.0.0"` → `">=2.0.0 <3.0.0"`. Comment fixed. |
| `library-chart/Chart.yaml` version | `0.11.3` → `0.11.4` |
| `rda-bundle.yaml` library_chart pin | `0.11.3` → `0.11.4` |
| `templates/web-nodejs/chart/Chart.yaml` lib pin | `0.11.3` → `0.11.4` |

## Test

All existing test suites stay green:
- passthrough-collision: 9/9 ✅
- provisioning: 8/8 ✅
- auto-ingress-ui: 8/8 ✅
- env-aliases: 8/8 ✅
- auth-seed: 5/5 ✅
- prometheus: 10/10 ✅
- dsl-mappings-schema: clean (4 charts) ✅

## Companion

- **idefxH/tilt-extension-suse-rda#11** — orthogonal "auto-detect new services[] type and re-vendor" issue. With this PR merged, `helm dep update` will pull redis. With #11 also fixed, the dev wouldn't even have to run `helm dep update` manually.

## Discovered

Live demo Apr 30. After all the previous fixes in flight, the user ran `rda add-service redis cache` + `tilt up`. Got "unknown resource payments-redis-master" because helm dep update silently skipped redis (not declared in deps[]).
