### PR TITLE
fix(library): redis dsl-mappings for AppCo standalone architecture (0.11.5)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.4
+version: 0.11.5
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -111,22 +111,27 @@ charts:
         # the redis container version. AppCo repackages as 2.x; if you
         # see "21.x" referenced anywhere it's the upstream Bitnami
         # convention and doesn't apply here.
-        # Service has -master suffix because the chart deploys a
-        # primary/replicas split. The DSL persistence.enabled /
-        # metrics.enabled paths lift onto master.* under the hood —
-        # see values_mapping.
+        #
+        # AppCo redis defaults to architecture=standalone (single
+        # replica), so the Service is just <release>-redis (no -master
+        # suffix — that's a Bitnami HA-mode artifact). Persistence and
+        # metrics keys are top-level under redis.* (no master.* prefix).
+        # Container resources are nested under
+        # podTemplates.containers.redis.resources because AppCo's
+        # PodTemplate-based schema separates init / app / sidecar
+        # resource budgets.
         service:
-          host: "{{ .Release.Name }}-redis-master"
+          host: "{{ .Release.Name }}-redis"
           port: 6379
         values_mapping:
           auth.password: redis.auth.password
-          persistence.enabled: redis.master.persistence.enabled
-          persistence.size: redis.master.persistence.size
+          persistence.enabled: redis.persistence.enabled
+          persistence.size: redis.persistence.resources.requests.storage
           metrics.enabled: redis.metrics.enabled
-          resources.requests.cpu: redis.master.resources.requests.cpu
-          resources.requests.memory: redis.master.resources.requests.memory
-          resources.limits.cpu: redis.master.resources.limits.cpu
-          resources.limits.memory: redis.master.resources.limits.memory
+          resources.requests.cpu: redis.podTemplates.containers.redis.resources.requests.cpu
+          resources.requests.memory: redis.podTemplates.containers.redis.resources.requests.memory
+          resources.limits.cpu: redis.podTemplates.containers.redis.resources.limits.cpu
+          resources.limits.memory: redis.podTemplates.containers.redis.resources.limits.memory
         # Redis password lives in the AOF / RDB snapshot once persistence
         # is on — flipping it after first init requires a PVC reset.
         # When persistence is off (default for redis), the auth seed
@@ -137,7 +142,7 @@ charts:
         binding_secret:
           - {key: type, literal: redis, skip_env: true}
           - {key: provider, literal: rda-appco, skip_env: true}
-          - {key: host, template: "{{ .Release.Name }}-redis-master"}
+          - {key: host, template: "{{ .Release.Name }}-redis"}
           - {key: port, literal: "6379"}
           - {key: password, from_dsl: auth.password, required: true}
 


### PR DESCRIPTION
AppCo redis 2.6.1-3.1 ships `architecture: standalone` by default — single-replica, not the Bitnami HA primary/replicas split my dsl-mappings entry assumed. Result: the bundle was generating `<release>-redis-master` references that didn't match any rendered Service, breaking the Tilt extension's workload resolution.

## What changes

- `service.host`: `{{ .Release.Name }}-redis-master` → `{{ .Release.Name }}-redis`
- `binding_secret[host].template`: same fix (used to populate the SBS Secret)
- `values_mapping`:
  - `persistence.enabled` → `redis.persistence.enabled` (top-level, no `master.`)
  - `persistence.size` → `redis.persistence.resources.requests.storage` (AppCo schema)
  - `resources.*` → `redis.podTemplates.containers.redis.resources.*` (AppCo PodTemplate-based schema)

Bumps library-chart to 0.11.5.

## Validated

End-to-end on macstudio Rancher Desktop:
- `rda render` produces correct projection (no more `master.persistence`)
- `helm template` renders `payments-redis` (Service, StatefulSet, headless, sentinel-headless), zero `-master`
- `payments-cache-binding.host` resolves to `payments-redis`
- auth-seed annotation present (`9ccb36c20315cffd`)
- env vars (CACHE_HOST/PORT/PASSWORD) wired correctly to the binding Secret

## Caveat

This locks the dsl-mappings to AppCo's standalone architecture. If users override `architecture: replication` or `cluster`, the Service name changes again. Future enhancement: detect via values resolution and switch the host template. For now: documented assumption.