### PR TITLE
fix(library 0.11.7): default redis.enabled: false (bug surfaced by live e2e on a postgres-only project)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.6
+version: 0.11.7
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/values.yaml
+++ b/library-chart/values.yaml
@@ -168,3 +168,15 @@ grafana:
   # Refs bundle issue #8.
   ui:
     expose: true
+
+# Disabled-by-default catch on `redis.enabled`. Helm dep `condition:`
+# semantics: when the path is MISSING from values entirely, Helm treats
+# the condition as 'no effect' and loads the dep regardless. So a missing
+# default here would make every project pull redis even without
+# `services[].type=redis` opting in. Closes a bug surfaced live: a
+# project with only postgresql in services[] still saw payments-redis
+# resources because nobody had explicitly written redis.enabled: false.
+# rda render writes redis.enabled: true into the overlay only when an
+# enabled redis service exists, so the user-facing default is off.
+redis:
+  enabled: false

--- a/templates/web-nodejs/Tiltfile
+++ b/templates/web-nodejs/Tiltfile
@@ -27,5 +27,9 @@ load('ext://suse-rda', 'suse_app')
 suse_app(
     name='{{ .Name }}',
     language='{{ .Language }}',
-    port=8080,
 )
+# port is derived from `suse-library.port` in chart/values.yaml — the
+# library chart's deployment renders containerPort and Service targetPort
+# from there, so values.yaml stays the single source of truth. Override
+# only by editing values.yaml; pass `port=NNN` here only if you need to
+# force a mismatch (the Tiltfile fails fast otherwise).

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.11.6
+    version: 0.11.7
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
## What changes

- **library 0.11.7**: `library-chart/values.yaml` adds top-level `redis: { enabled: false }` default. Closes a real bug surfaced by live e2e: a project with only `services[].type=postgresql` still rendered `payments-redis` resources because Helm dep `condition:`s have NO effect when the path is missing entirely (vs resolving to false, which DOES gate). Other AppCo deps (postgresql, prometheus, grafana) all had explicit defaults — only redis was missing because PR #71 added the dep without rolling forward the defaults block. Long-form comment in values.yaml explains the gotcha for the next contributor.

- **Library version**: 0.11.6 → 0.11.7. Bundle template’s `templates/web-nodejs/chart/Chart.yaml` dep pin bumped in lockstep.

- **Template Tiltfile cleanup**: `templates/web-nodejs/Tiltfile` drops the redundant `port=8080` argument. Pairs with tilt-extension-suse-rda#13 (port derived from `suse-library.port` in chart/values.yaml). The new scaffold ships a minimal Tiltfile.

## Validated

- `helm template` on a postgres-only project no longer emits any `payments-redis*` resources.
- With `services[].type=redis, enabled: true`, `rda render` writes `redis.enabled: true` into the overlay and the dep loads as expected.
- Closes the redis-default bug; pairs with #74 (already merged) for the template Chart.yaml version bump.
