### PR TITLE
feat(library 0.11.8): plural ingress.hosts in DSL + localtest.me default hosts

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.7
+version: 0.11.8
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -176,7 +176,14 @@ charts:
           retention: prometheus.server.retention
           # UI Ingress.
           ingress.enabled: prometheus.server.ingress.enabled
+          # Plural `hosts: [...]` is canonical (matches the app-level DSL
+          # at suse-library.ingress.hosts). Singular `host: <str>` stays
+          # supported for back-compat with bundles ≤0.11.7 — projected to
+          # hosts[0] via the bracket-notation projection (closes
+          # rda-cli#75). Both writeable; if a project sets BOTH, the
+          # render's seen-types collision detection will warn loud.
           ingress.host: prometheus.server.ingress.hosts[0]
+          ingress.hosts: prometheus.server.ingress.hosts
           # Resources are server-scoped (the other prometheus chart
           # components — alertmanager, exporters, pushgateway — are
           # disabled by default in the library's values.yaml).
@@ -206,7 +213,12 @@ charts:
           auth.admin.name: grafana.adminUser
           auth.admin.password: grafana.adminPassword
           ingress.enabled: grafana.ingress.enabled
+          # Plural `hosts: [...]` is canonical (matches the app-level DSL
+          # at suse-library.ingress.hosts). Singular `host: <str>` stays
+          # supported for back-compat — projected to hosts[0] via
+          # bracket-notation (closes rda-cli#75). Both writeable.
           ingress.host: grafana.ingress.hosts[0]
+          ingress.hosts: grafana.ingress.hosts
           metrics.enabled: grafana.grafana.ini.metrics.enabled
           persistence.enabled: grafana.persistence.enabled
           persistence.size: grafana.persistence.size

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.11.7
+    version: 0.11.8
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in

--- a/templates/web-nodejs/chart/values.yaml
+++ b/templates/web-nodejs/chart/values.yaml
@@ -21,11 +21,19 @@ suse-library:
 
   # ─── Ingress (cluster Traefik / FIPS variant) ──────────────────────
   # The library auto-renders an Ingress when this block is present.
-  # Default host {{ .Name }}.localhost resolves on macOS / Rancher
-  # Desktop without /etc/hosts edits; change for staging+.
+  #
+  # Default host uses localtest.me — a public wildcard DNS that resolves
+  # *.localtest.me to 127.0.0.1 from any OS, no /etc/hosts edits needed.
+  # Works on macOS, Linux, AND Windows out of the box. The shorter
+  # `<name>.localhost` form is also fine on macOS / Linux (where modern
+  # mDNS resolves *.localhost to 127.0.0.1) but it's NOT universal
+  # — Windows resolution is hit-or-miss without registry tweaks.
+  # Change all hosts for staging+.
   ingress:
     enabled: true
-    hosts: [{{ .Name }}.localhost]
+    hosts:
+      - {{ .Name }}.localtest.me
+      # - {{ .Name }}.localhost  # alternative (macOS / Linux only)
 
   image:
     repository: {{ .Name }}


### PR DESCRIPTION
## What changes (bundle 0.11.8)

Three fixes surfaced live during a grafana-with-ingress e2e.

### 1. Plural `ingress.hosts` canonical in the DSL

`services[].ingress` now accepts `hosts: [list]` (plural, matches the app-level DSL convention `suse-library.ingress.hosts`). Singular `host: <str>` stays for back-compat. dsl-mappings.yaml extended for grafana + prometheus.

### 2. `localtest.me` default hosts (universal)

Bundle template scaffolds the app-level ingress with `<name>.localtest.me` instead of `<name>.localhost`. localtest.me is public wildcard DNS, resolves *.localtest.me to 127.0.0.1 from any OS — works on Mac/Linux/Windows out of the box. `.localhost` (Mac/Linux mDNS only) is shipped as a commented sibling.

### 3. **`rda-bundle.yaml` version sync** ← real bug fix

The bundle's manifest `rda-bundle.yaml` has a `library_chart.version` field that **`rda upgrade` reads** to compute the target version. It was at 0.11.4 — never bumped through 0.11.5/0.11.6/0.11.7/0.11.8 across PRs #71/#73/#75. Symptom reported live: `rda upgrade` lied with `already up to date (library version 0.11.4)` while the actual library was 0.11.8.

Fix: bump rda-bundle.yaml to 0.11.8 in lockstep with library-chart/Chart.yaml. A long-form comment in the file warns the next contributor that the two MUST stay equal. Follow-up: bundle issue #76 (CONTRIBUTING checklist) gets a note about this; a test asserting equality is filed separately as a follow-up.

## Validated

- `rda render` smoke test on a fresh `rda new + add-service grafana dashboard` produces the canonical plural shape with localtest.me defaults.
- `helm template` emits the Ingress resource with the host populated.

## Migration

Users running `rda upgrade` after this merges must `rm -rf ~/.cache/rda/bundles/` first to bust the stale 0.11.4 manifest. `rda doctor bundle-cache-fresh-vs-source` (rda-cli#71) would have caught this proactively — another reason to land that.
