### PR TITLE
feat(library 0.11.9): ui.expose default to false (drop dup library auto-Ingress)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.8
+version: 0.11.9
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/values.yaml
+++ b/library-chart/values.yaml
@@ -132,15 +132,20 @@ prometheus:
   server:
     persistentVolume:
       enabled: false
-  # Auto-Ingress for the Prometheus UI. When prometheus.enabled is
-  # true, the library renders an Ingress at prometheus.<release>.localhost
-  # so the dev opens the expression browser from a browser without
-  # configuring a host explicitly. Override:
-  #   prometheus.ui.expose: false  # opt out
-  #   prometheus.ui.host: "..."    # custom host
-  # Refs bundle issue #8.
+  # Auto-Ingress for the Prometheus UI. The library used to render its
+  # own Ingress (via templates/ingress-ui.yaml) when this was true,
+  # because per-chart Ingress shapes differed enough that the DSL
+  # couldn't bridge them. Now (bundle 0.11.9+) the DSL `services[]
+  # .ingress.hosts: [...]` projects via dsl-mappings to the chart-
+  # native Ingress directly — no library detour, no duplication. The
+  # default flipped to `false` to avoid two Ingress resources
+  # (prometheus's own + library's auto) for the same host. Devs who
+  # want the library auto-Ingress (e.g. to override host without
+  # touching the prometheus block) flip this to true explicitly.
+  # Refs bundle issue #8 (the original auto-Ingress design) and the
+  # post-mortem that flipped the default.
   ui:
-    expose: true
+    expose: false
   alertmanager:
     enabled: false
   prometheus-node-exporter:
@@ -161,13 +166,20 @@ grafana:
   # opinion bundle's value prop.
   metrics:
     enabled: true
-  # Auto-Ingress for the Grafana UI. When grafana.enabled is true, the
-  # library renders an Ingress at grafana.<release>.localhost. Override:
-  #   grafana.ui.expose: false  # opt out
-  #   grafana.ui.host: "..."    # custom host
-  # Refs bundle issue #8.
+  # Auto-Ingress for the Grafana UI. The library used to render its
+  # own Ingress (via templates/ingress-ui.yaml) when this was true,
+  # because per-chart Ingress shapes differed enough that the DSL
+  # couldn't bridge them. Now (bundle 0.11.9+) the DSL `services[]
+  # .ingress.hosts: [...]` projects via dsl-mappings to the chart-
+  # native Ingress directly — no library detour, no duplication. The
+  # default flipped to `false` to avoid two Ingress resources
+  # (grafana's own + library's auto) for the same host. Devs who want
+  # the library auto-Ingress (e.g. to override host without touching
+  # the grafana block) flip this to true explicitly. Refs bundle
+  # issue #8 (the original auto-Ingress design) and the post-mortem
+  # that flipped the default.
   ui:
-    expose: true
+    expose: false
 
 # Disabled-by-default catch on `redis.enabled`. Helm dep `condition:`
 # semantics: when the path is MISSING from values entirely, Helm treats

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.8
+  version: 0.11.9
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.11.8
+    version: 0.11.9
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
Defaults > helper logic. Library auto-Ingress (`<chart>.ui.expose: true` default) was a shortcut from before dsl-mappings — now it duplicates the chart-native Ingress whenever the user uses `services[].ingress.hosts`. Flip the default to false; document the migration. Bumps in lockstep across library Chart.yaml + rda-bundle.yaml + template Chart.yaml. Tests green.