### PR TITLE
fix(library 0.11.10): deployment.yaml iterates enabledServices (drift with binding-secret)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.9
+version: 0.11.10
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/deployment.yaml
+++ b/library-chart/templates/deployment.yaml
@@ -40,8 +40,17 @@ spec:
             - {name: SERVICE_BINDING_ROOT, value: /bindings}
             # 12-factor PORT — user code MUST respect process.env.PORT.
             - {name: PORT, value: "{{ .Values.port }}"}
-            {{- /* DSL path: project env from each services[] entry (Phase 1) */ -}}
-            {{- range $i, $svc := .Values.services }}
+            {{- /* DSL path: project env from each ENABLED services[] entry.
+                   Iterates the same enabledServices helper as binding-secret.yaml
+                   so a disabled service doesn't end up with envFromBinding /
+                   volumeMounts referencing a Secret that was never rendered.
+                   Live e2e Apr 30: a prometheus service scaffolded with
+                   `enabled: false` had the deployment mount /bindings/metrics
+                   while binding-secret.yaml correctly skipped it → pod
+                   MountVolume.SetUp failed with `secret payments-metrics-binding
+                   not found`. Single source of truth fixes the drift. */ -}}
+            {{- $enabled := include "suse-library.dsl.enabledServices" $ | fromJsonArray }}
+            {{- range $i, $svc := $enabled }}
             # ─── DSL binding {{ $svc.binding }} (type {{ $svc.type }}) ───
             {{- include "suse-library.dsl.envFromBinding" (dict "svc" $svc "release" $.Release.Name "root" $) | nindent 12 }}
             {{- end }}
@@ -82,7 +91,7 @@ spec:
                 services have no Secret to mount (the dev wired the
                 connection details elsewhere).
             */}}
-            {{- range $i, $svc := .Values.services }}
+            {{- range $i, $svc := $enabled }}
             {{- $prov := $svc.provisioning | default "local" }}
             {{- if ne $prov "external" }}
             - {name: {{ printf "binding-%s" $svc.binding }}, mountPath: {{ printf "/bindings/%s" $svc.binding }}, readOnly: true}
@@ -114,7 +123,7 @@ spec:
             DSL binding volumes — one Secret-backed volume per non-external
             services[] entry. Pairs with the volumeMounts loop above.
         */}}
-        {{- range $i, $svc := .Values.services }}
+        {{- range $i, $svc := $enabled }}
         {{- $prov := $svc.provisioning | default "local" }}
         {{- if ne $prov "external" }}
         - name: {{ printf "binding-%s" $svc.binding }}

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.9
+  version: 0.11.10
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.11.9
+    version: 0.11.10
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
Live e2e Apr 30: prometheus service with `enabled: false` (the inert default from rda add-service) caused the app pod to fail with `secret payments-metrics-binding not found`. binding-secret.yaml correctly skipped the disabled entry, but deployment.yaml iterated all of `.Values.services` — drift across templates. Fix: deployment.yaml uses the same enabledServices helper as binding-secret.yaml. Single source of truth. Library 0.11.10 in lockstep with rda-bundle.yaml + template Chart.yaml.