### PR TITLE
feat(library 0.11.11): bootstrap PCD — SPEC.md + test guards + CONTRIBUTING (Phase 1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing to `rda-opinion-bundle-example`
+
+This bundle is governed by **PCD** (Post-Coding Development): the
+canonical contract lives in `library-chart/SPEC.md`, code follows the
+spec, every behavior change requires a spec update in the same commit.
+
+## Workflow
+
+```
+You change behavior  →  SPEC.md captures it  →  Code follows  →  Tests lock it in
+       ↑                                                                |
+       └──────────────────── PR review ─────────────────────────────────┘
+```
+
+## Pre-PR checklist
+
+Before opening a PR that changes the library chart's behavior or
+catalogue, walk through this list. The four bumps below MUST land in
+**the same commit** — drift between any two of them has shipped real
+bugs (see SPEC.md LESSONS).
+
+### 1. Spec first
+
+- [ ] `library-chart/SPEC.md` updated with the new BEHAVIOR section, or
+      the existing one amended. Reference the issue / PR number.
+- [ ] A new `## MILESTONE: X.Y.Z` block at the bottom of SPEC.md
+      describing the change (what / why / discovered context). The
+      MILESTONE format mirrors `idefxH/rda-cli/rda.md`.
+- [ ] `library-chart/SPEC.md`'s `META.Version` field bumped to the new
+      version.
+
+### 2. Code
+
+- [ ] Helm template / helper changes implement the spec.
+- [ ] `library-chart/Chart.yaml`'s `version` bumped to match `SPEC.md`'s
+      `META.Version`.
+
+### 3. Lockstep
+
+- [ ] `rda-bundle.yaml`'s `library_chart.version` bumped to match.
+      `rda upgrade` reads THIS field — drift makes it silently lie.
+      The `tests/manifest-version-sync/` test asserts equality.
+- [ ] `templates/web-nodejs/chart/Chart.yaml`'s `suse-library` dep
+      version bumped. Fresh `rda new` projects pin to this.
+
+### 4. Tests
+
+- [ ] If the change establishes a new invariant, add a test under
+      `library-chart/tests/<invariant>/` (run.sh + check.py). See
+      `services-iteration-grep` and `dep-defaults-presence` for the
+      pattern.
+- [ ] Run all bundle tests: `for d in library-chart/tests/*/; do bash
+      "$d/run.sh"; done`. All must exit 0.
+
+### 5. Specific guards already in place
+
+These tests run on every PR — make sure your change doesn't trip them:
+
+| Test | What it asserts | Failed historically by |
+|---|---|---|
+| `manifest-version-sync` | `Chart.yaml.version == rda-bundle.yaml.library_chart.version` | PRs #71/#73/#75 (manifest stuck at 0.11.4 across 4 bumps) |
+| `services-iteration-grep` | Every chart template iterates services[] via `enabledServices` helper | PR #71 (deployment.yaml iterated raw `.Values.services`, broke disabled-service pods) |
+| `dep-defaults-presence` | Every Helm dep in `Chart.yaml` has `<name>.enabled: false` default in `values.yaml` | PR #71 (redis dep added without default — loaded unconditionally) |
+| `catalog-consistency` | `dsl-mappings.yaml` ↔ `rda-devx-catalog/CATALOG.md` consistency | (pre-existing) |
+| `auth-seed` | binding-secret renders the auth-seed annotation when stateful | (pre-existing) |
+| `auto-ingress-ui` | UI Ingress only when `ui.expose: true` | (pre-existing) |
+| `passthrough-collision` | DSL field × passthrough field detect collisions | (pre-existing) |
+| `dsl-mappings-schema` | `dsl-mappings.yaml` parses against the schema | (pre-existing) |
+| `provisioning` | local / shared / external behaviour is consistent | (pre-existing) |
+| `prometheus` | prometheus-specific projection invariants | (pre-existing) |
+| `env-aliases` | env_aliases project the right additional env vars | (pre-existing) |
+
+## When NOT to bump versions
+
+- Documentation-only changes (this file, comments in templates,
+  README typos) don't bump the version. Add the change as a
+  `## MILESTONE: X.Y.Z+next` placeholder for the next behavior bump.
+- Tests added for existing behavior (no new BEHAVIOR section) bump
+  the version since they lock in an invariant — that IS a behavior
+  change, even if subtle. Add a one-line MILESTONE entry.
+
+## Adding a new chart to the catalogue
+
+When you add a Helm dep (e.g. mariadb, kafka, mongodb), the workflow
+spans 5 files in lockstep. The `dep-defaults-presence` test will
+catch step 3 if you forget; nothing else is automated.
+
+1. **`library-chart/Chart.yaml`** — append the dep with
+   `condition: <chart>.enabled` and the AppCo OCI repository.
+2. **`library-chart/values.yaml`** — add `<chart>: { enabled: false }`
+   default block (with comments mirroring the other chart blocks).
+3. **`library-chart/dsl-mappings.yaml`** — add the entry: `service.host`
+   template (release-templated), `port`, `values_mapping` per dimension,
+   `binding_secret` keys, optional `auth_seed_paths` if stateful,
+   optional `env_aliases` for the SBS canonical keys.
+4. **`library-chart/SPEC.md`** — log the addition under the next
+   MILESTONE block. Bump META.Version.
+5. **`rda-bundle.yaml`** — bump `library_chart.version` AND append the
+   chart's `type_name` under `service_catalog`.
+6. **`templates/web-nodejs/chart/Chart.yaml`** — bump the dep pin.
+7. **rda-cli** — companion PR adds a `case "<chart>"` to `dslDefaultsFor`
+   in `code/cmd/add_service.go` so `rda add-service <chart> <binding>`
+   produces the right scaffold.
+
+## Anatomy of a good PR description
+
+Mirror what `rda-cli` PRs do (look at recent merges for examples):
+
+```markdown
+## What changes
+
+- Concrete list of behavior changes
+- Cross-links to spec sections + tests
+
+## Why
+
+The user-visible problem this closes. Bonus: a specific bug discovered
+live. Lessons go in SPEC.md LESSONS, not the PR body.
+
+## Migration
+
+What existing projects need to do (re-vendor, edit values, etc.).
+Link to the relevant `rda upgrade` / Tilt-cache reset steps.
+
+## Tests
+
+What's been verified. List the bundle tests run + the e2e smoke if
+applicable.
+```

--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.10
+version: 0.11.11
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -1,0 +1,379 @@
+# suse-library
+
+## META
+Deployment:   helm-library-chart
+Version:      0.11.11
+Spec-Schema:  0.1.0
+Author:       François-Xavier Houard <fx.houard@gmail.com>
+License:      Apache-2.0
+Verification: none
+Safety-Level: QM
+
+`suse-library` is the Helm library chart at the heart of the SUSE
+Rancher Developer Access opinion bundle. It encapsulates the
+application Deployment, the Service Binding Specification (SBS) wiring,
+and the references to the SUSE Application Collection (AppCo) sub-charts
+that projects opt into via `services[]` DSL entries.
+
+This SPEC.md is the canonical contract: what the library guarantees,
+which keys it consumes, which resources it emits, which invariants must
+hold across templates. Code (helpers + templates) follows the spec, and
+every behaviour change requires a spec update in the same commit
+(see CONTRIBUTING.md).
+
+The companion `rda` CLI's `rda.md` spec sits at the consumer side of
+the same DSL — it scaffolds projects, projects services[] into chart-
+specific values overlays, and runs library-aware doctor checks.
+
+## CONVENTIONS
+
+- `<release>` — the Helm release name (the `name:` arg to `helm install`,
+  also `{{ .Release.Name }}` at template time).
+- `<chart>` — an AppCo chart name like `postgresql`, `redis`,
+  `prometheus`, `grafana`. Every reference is verbatim, no alias.
+- `<binding>` — the symbolic name a project's app uses to reach a
+  service (env-var prefix, Secret name suffix, SBS mount).
+- `services[]` — the unified DSL, written by the dev (or by `rda
+  add-service`) at `chart/values.yaml` under `suse-library.services`.
+
+## BEHAVIOR: services-iteration
+Constraint: required
+
+Every chart template that walks the `services[]` DSL list MUST iterate
+the **enabled subset** computed by `suse-library.dsl.enabledServices`,
+not raw `.Values.services`. Single source of truth across all consumer
+templates: a disabled service stays inert at every layer (no
+binding-secret, no env var, no volume, no mount, no chart-level
+`<chart>.enabled` flip).
+
+Enforced templates (Phase 1):
+- `templates/binding-secret.yaml` — renders one Secret per enabled entry
+- `templates/deployment.yaml` — env (envFromBinding), volume mounts,
+  volume Secret references — all on the enabled subset
+- `templates/service.yaml` (no services iteration today; may grow)
+- `templates/ingress.yaml` (no services iteration today; may grow)
+
+Test guard: `tests/services-iteration-grep/` greps every file under
+`library-chart/templates/` for `range.*\.Values\.services`. A match
+without an `enabledServices`-derived `$enabled` in scope fails the test
+loud at PR review. See LESSONS at the end for the live e2e bug that
+motivated this invariant.
+
+Helper definition (in `templates/_helpers.tpl`):
+
+  {{- define "suse-library.dsl.enabledServices" -}}
+    iterates .Values.services, filters where !hasKey(svc, 'enabled')
+    OR svc.enabled == true; returns JSON-encoded list (Helm named
+    templates can only return strings; consumers do `| fromJsonArray`).
+  {{- end -}}
+
+## BEHAVIOR: dep-defaults-presence
+Constraint: required
+
+Every Helm dep declared in `library-chart/Chart.yaml` MUST have a
+matching `<chart>.enabled: false` (or any boolean, but conventionally
+false) default key in `library-chart/values.yaml`. Missing the default
+makes Helm's `condition: <chart>.enabled` a NO-OP — the dep loads
+unconditionally on every install, regardless of whether the project
+opted in via services[].
+
+Discovered live: redis dep added in #71 without the corresponding
+default → every project pulled redis even when only postgresql was in
+services[]. Closed in #75.
+
+Test guard: `tests/dep-defaults-presence/` walks every dep in
+`library-chart/Chart.yaml` and checks `library-chart/values.yaml` for a
+`<chart>.enabled` key. Fails loud naming the missing chart.
+
+## BEHAVIOR: manifest-version-sync
+Constraint: required
+
+`library-chart/Chart.yaml`'s `version` field and
+`rda-bundle.yaml`'s `library_chart.version` field MUST be equal in
+every commit. The bundle manifest is what `rda upgrade` reads to
+compute the upgrade target — drift makes `rda upgrade` silently lie
+("already up to date" at the manifest's stale version while the chart
+is newer).
+
+Discovered live: 4 consecutive bumps (0.11.5/6/7/8) shipped with the
+manifest stuck at 0.11.4. Closed in #78. Test added then.
+
+Test guard: `tests/manifest-version-sync/` (already present).
+
+## BEHAVIOR: dsl-mappings-target-validity
+Constraint: required
+
+Every `values_mapping` target path in `library-chart/dsl-mappings.yaml`
+MUST be parseable by `rda render` (rda-cli's `internal/render` package).
+The contract:
+- Path components separated by `.`
+- Bracket notation `name[N]` denotes an array index (closes
+  rda-cli#75); the projection grows the list with nil placeholders
+- Malformed brackets (`hosts[`, `hosts[]`, `hosts[abc]`) are rejected
+  loud
+- The leaf may be either a scalar (e.g. `chart.auth.password`) or a
+  list element (`chart.ingress.hosts[0]`)
+
+Discovered live: prometheus + grafana ingress.host singular projected
+to `chart.ingress.hosts[0]`. Without bracket support the literal key
+`hosts[0]` was written instead of a list — Helm rendered no Ingress.
+Closed in rda-cli#75.
+
+Test guard (Phase 2): `tests/dsl-mappings-targets-valid/` parses every
+target path with the same rules `rda render` uses, fails on malformed
+or unsupported syntax. Currently parked until rda-cli's projection.go
+is published as a re-usable parser; today the bundle relies on
+rda-cli's tests covering the same surface.
+
+## BEHAVIOR: binding-secret-schema
+Constraint: required (Phase 2 — captures existing implicit contract)
+
+Every binding-secret rendered by `templates/binding-secret.yaml` MUST
+follow the schema:
+
+  Secret name:           `<release>-<binding>-binding`
+  Mounted at (in pod):   `/bindings/<binding>/`
+  Labels (mandatory):
+    app.kubernetes.io/name      <release>
+    app.kubernetes.io/managed-by Helm
+    app.kubernetes.io/instance  <release>
+    rda.suse.com/library-version <chart-version>
+    rda.suse.com/provisioning   local | shared | external
+    service.binding/binding-name <binding>
+    service.binding/binding-type <chart>
+  Annotations (mandatory when stateful, i.e. auth_seed_paths declared):
+    rda.suse.com/source         services[binding=<binding>].type=<chart>.provisioning=<prov>
+    rda.suse.com/helper         suse-library.dsl.bindingSecretFrom
+    rda.suse.com/auth-seed      <16-char sha256 of auth fields>
+  stringData keys (always present):
+    type                        the AppCo chart name
+    provider                    rda-appco | <overlay-defined> | <user-defined>
+    host                        Service FQDN (release-templated)
+    port                        chart-default port (string, quoted)
+  stringData keys (conditionally present, per dsl-mappings.yaml binding_secret):
+    username, password, database, url, adminUser, adminPassword, …
+
+The 12-factor env-var projection in `_helpers.tpl envFromBinding` reads
+this Secret's keys, projecting `<BINDING>_<KEY>` env vars (uppercase,
+snake_case from the SBS-canonical key) PLUS any `env_aliases` declared
+in dsl-mappings (e.g. `username` aliased to `user` for libpq).
+
+Test guard (Phase 2): `tests/binding-secret-schema/` runs `helm
+template` on a fixture project and asserts every binding-secret
+matches the schema.
+
+## BEHAVIOR: ingress-conventions
+Constraint: required (Phase 2 — captures existing implicit contract)
+
+Two ingress paths exist in the library:
+
+1. **App-level ingress** — `suse-library.ingress.enabled` + `hosts:
+   [list]`. Renders one Ingress fronting the application's Service.
+   Plural list canonical (matches the DSL convention everywhere).
+
+2. **Service-level ingress** — declared via the DSL at
+   `services[].ingress.enabled` + `hosts: [...]`. Projected by `rda
+   render` to the chart-native `<chart>.ingress.hosts` (or
+   `<chart>.server.ingress.hosts` for prometheus, per dsl-mappings).
+   The chart-native Ingress is the authoritative one. Bundle 0.11.9
+   flipped the legacy `<chart>.ui.expose: true` default to `false` so
+   the library-emitted auto-Ingress at
+   `templates/ingress-ui.yaml` no longer duplicates the chart-native
+   one. Devs who need the library auto-Ingress (override host without
+   touching the chart's own ingress block) flip `ui.expose` back to
+   true explicitly.
+
+Singular `services[].ingress.host: <str>` is back-compat-supported via
+the bracket-notation projection (`grafana.ingress.hosts[0]`); plural
+is the canonical form.
+
+## BEHAVIOR: validateConsistency
+Constraint: required
+
+`templates/_helpers.tpl::suse-library.dsl.validateConsistency` runs at
+every helm template invocation (called from `binding-secret.yaml`).
+Phase 1 checks (on the **enabled** subset only — disabled entries are
+inert scaffolds, not failure conditions):
+
+- every entry has a non-empty `binding`
+- every entry has a recognised `type` (must be in dsl-mappings.yaml)
+- bindings are unique within services[]
+- for stateful types (auth_seed_paths declared): if a binding-secret
+  already exists in the cluster (= chart was deployed before), its
+  `rda.suse.com/auth-seed` annotation must match the freshly-computed
+  seed. Mismatch means the dev edited an auth field after first init
+  of the PVC; chart sub-init won't re-run, the new credentials don't
+  take, runtime fails with confusing auth errors. Fails loud at
+  template time with the nuke recipe. Closed bundle issue #63.
+
+The legacy `<chart>.enabled` consistency check (pre-0.11.6) was
+removed — chart-level enable is now derived by `rda render` and lives
+only in the auto-generated overlay.
+
+---
+
+## MILESTONE: 0.11.0
+Status: released
+
+- Initial `suse-library` library chart with the unified DSL
+  (`apiVersion: rda.suse.com/v1alpha1`, `services[]`).
+- `templates/_helpers.tpl` ships data-driven helpers reading
+  `dsl-mappings.yaml` instead of hardcoded if/else arms — adding a
+  chart = one YAML entry.
+- Legacy `<chart>.enabled` gated path remains for back-compat.
+
+## MILESTONE: 0.11.1
+Status: released
+
+- Bug fix: helper indentation produced invalid YAML on consecutive
+  binding-secrets. Restructured `bindingSecretFrom` to emit clean
+  doc separators.
+
+## MILESTONE: 0.11.2
+Status: released
+
+- BEHAVIOR/validateConsistency: stateful charts (auth_seed_paths
+  declared in dsl-mappings.yaml) get the auth-seed annotation on
+  their binding-secret. Closes bundle #63 (auth drift on PVC re-deploy).
+
+## MILESTONE: 0.11.3
+Status: released
+
+- New chart catalogued: `prometheus` (29.x). Joins postgresql,
+  redis, grafana in the dsl-mappings.yaml v1alpha1 lineup.
+
+## MILESTONE: 0.11.4
+Status: released
+
+- Bug fix: `redis` declared in Chart.yaml as a dep with
+  `condition: redis.enabled`. Without #75's defaults follow-up the
+  dep loaded by default — closed in 0.11.7.
+
+## MILESTONE: 0.11.5
+Status: released
+
+- BEHAVIOR/dsl-mappings: redis entry rewritten for AppCo's
+  `architecture: standalone` default — Service is `<release>-redis`
+  (no `-master` Bitnami HA artifact). values_mapping for persistence
+  + resources rewired to AppCo's PodTemplate-based schema.
+
+## MILESTONE: 0.11.6
+Status: released
+
+- BEHAVIOR/services-iteration introduced: new helper
+  `enabledServices` filters `services[].enabled == true` (default true
+  if absent). `binding-secret.yaml` + validateConsistency consume the
+  filtered set. Closes the rda-cli#67 inert-scaffold contract.
+
+## MILESTONE: 0.11.7
+Status: released
+
+- BEHAVIOR/dep-defaults-presence: missing `redis: { enabled: false }`
+  default added to `library-chart/values.yaml`. Closes the silent
+  redis-deploys-by-default bug from 0.11.4.
+
+## MILESTONE: 0.11.8
+Status: released
+
+- BEHAVIOR/dsl-mappings: `ingress.hosts` plural canonical alongside
+  the back-compat singular `ingress.host`. Pairs with rda-cli#75's
+  bracket-notation projection.
+- Bundle template `chart/values.yaml`: app-level ingress default
+  switched to `<name>.localtest.me` (universal wildcard DNS) with
+  `<name>.localhost` shipped as a commented sibling for macOS/Linux.
+- BEHAVIOR/manifest-version-sync introduced: `rda-bundle.yaml`'s
+  `library_chart.version` synced to 0.11.8. Test guard added at
+  `tests/manifest-version-sync/`.
+
+## MILESTONE: 0.11.9
+Status: released
+
+- BEHAVIOR/ingress-conventions: `<chart>.ui.expose` default flipped
+  to `false` for prometheus + grafana. Library auto-Ingress is now
+  opt-in only; chart-native Ingress (driven by DSL services[].ingress)
+  is the canonical path. Closes a duplication caught live (two
+  Ingresses for grafana UI — chart-native + library auto).
+
+## MILESTONE: 0.11.10
+Status: released
+
+- BEHAVIOR/services-iteration extended: `templates/deployment.yaml`
+  now iterates the `enabledServices` helper for env, volumeMounts,
+  and volumes. Closes a drift caught live: a project with a disabled
+  service (the inert-default scaffold) had its app pod fail with
+  `MountVolume.SetUp failed: secret <release>-<binding>-binding not
+  found` — binding-secret correctly skipped the disabled entry, but
+  deployment iterated raw `.Values.services` and tried to mount the
+  missing Secret. Single source of truth restored.
+
+## MILESTONE: 0.11.11
+Status: in-progress
+
+- BEHAVIOR/services-iteration enforced by a new test:
+  `tests/services-iteration-grep/` greps every file under
+  `templates/` for `range.*\.Values\.services` and fails loud if
+  found without an `enabledServices`-derived `$enabled` upstream.
+- BEHAVIOR/dep-defaults-presence enforced by a new test:
+  `tests/dep-defaults-presence/` ensures every chart dep in
+  `Chart.yaml` has a matching `<chart>.enabled` default key in
+  `values.yaml`.
+- New `library-chart/SPEC.md` (this file) — the PCD canonical contract
+  for everything above.
+- `CONTRIBUTING.md` mandates SPEC.md updates before any behavior
+  change. Adds a checklist matching the `rda-cli/rda.md` workflow:
+  spec → code → tests → version bump in lockstep across all four
+  files (library Chart.yaml, rda-bundle.yaml, template Chart.yaml,
+  SPEC.md META.Version).
+
+---
+
+## LESSONS
+
+This section is a running post-mortem — every spec-relevant bug we
+catch live gets a one-paragraph entry here, anchoring the BEHAVIOR
+sections above. The format trades brevity for traceability: a future
+contributor reading SPEC.md sees both the rule AND the live evidence
+that produced it.
+
+**Lesson 1 — services-iteration drift (0.11.10).** A project with a
+service scaffolded by `rda add-service prometheus metrics` (which
+writes `enabled: false` per the inert-by-default contract from
+rda-cli#67) had its app pod fail with `MountVolume.SetUp failed:
+secret payments-metrics-binding not found`. binding-secret.yaml
+correctly skipped the disabled entry; deployment.yaml still iterated
+raw `.Values.services`. Two pieces of the same chart machinery, two
+iteration targets, contract silently broke at runtime. Fix:
+deployment.yaml uses enabledServices. Lesson: **invariants implicit
+across files are zero-cost to break and high-cost to debug.**
+Externalise into SPEC.md, lock with a test.
+
+**Lesson 2 — dep-defaults absent (0.11.7).** PR #71 added redis as a
+Helm dep on `library-chart/Chart.yaml` with `condition: redis.enabled`
+— but did NOT add the corresponding `redis: { enabled: false }` default
+in `library-chart/values.yaml`. Helm's contract: when the path is
+missing entirely from values, the condition has no effect — the dep
+loads unconditionally. The bug shipped through 0.11.4–0.11.6 because
+nothing in the contributor flow caught the missing default. Fix in
+#75. Lesson: **chart-level defaults aren't optional, they're part of
+the contract. Externalise the rule, lock with a test.**
+
+**Lesson 3 — manifest version drift (0.11.8).** `rda-bundle.yaml`'s
+`library_chart.version` field — read by `rda upgrade` to resolve the
+target version — was missed across 4 consecutive library bumps. Result:
+`rda upgrade` lied with `already up to date 0.11.4` while library was
+at 0.11.8. Fix in #78. Test added then. Lesson: **same principle —
+invariants across files don't enforce themselves.**
+
+**Lesson 4 — host singular vs plural (0.11.8 + rda-cli#75).** The DSL
+exposed `services[].ingress.host` (singular) as the only field. Devs
+mentally reached for `hosts: [...]` (plural list) matching the
+app-level convention `suse-library.ingress.hosts`. `rda render`
+silently ignored the unknown key, no Ingress rendered, no Tilt UI link.
+Fix: dsl-mappings supports both, plural canonical. Lesson:
+**inconsistency between DSL layers is a UX bug. Same shape across the
+stack.**
+
+These four lessons share a class: **contracts that span multiple files
+without a check are bugs waiting to happen.** Every BEHAVIOR section
+above pairs with a test guard precisely to make these classes
+unproducable on a fresh PR.

--- a/library-chart/tests/dep-defaults-presence/check.py
+++ b/library-chart/tests/dep-defaults-presence/check.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Assert every Helm dep declared in `library-chart/Chart.yaml` has a
+matching `<chart>.enabled` default key in `library-chart/values.yaml`.
+
+Why: see SPEC.md BEHAVIOR/dep-defaults-presence. Helm's `condition:
+<chart>.enabled` is a NO-OP when the path is missing entirely from
+values — the dep loads unconditionally. The redis dep added in #71
+shipped this bug across 4 releases (0.11.4–0.11.6) before being caught
+live and fixed in #75.
+
+Layout: same as the other library-chart/tests/* (run.sh + check.py).
+"""
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "PyYAML not installed; pip3 install pyyaml or python3 -m pip install pyyaml\n"
+    )
+    sys.exit(2)
+
+
+def main() -> int:
+    here = os.path.dirname(os.path.abspath(__file__))
+    chart_root = os.path.abspath(os.path.join(here, "..", ".."))
+    chart_yaml_path = os.path.join(chart_root, "Chart.yaml")
+    values_yaml_path = os.path.join(chart_root, "values.yaml")
+
+    if not os.path.isfile(chart_yaml_path):
+        sys.stderr.write(f"FAIL: missing {chart_yaml_path}\n")
+        return 1
+    if not os.path.isfile(values_yaml_path):
+        sys.stderr.write(f"FAIL: missing {values_yaml_path}\n")
+        return 1
+
+    with open(chart_yaml_path) as f:
+        chart = yaml.safe_load(f) or {}
+    with open(values_yaml_path) as f:
+        values = yaml.safe_load(f) or {}
+
+    deps = chart.get("dependencies") or []
+    if not deps:
+        print("OK: no dependencies declared (vacuously true)")
+        return 0
+
+    missing = []
+    wrong_type = []
+
+    for dep in deps:
+        name = dep.get("name")
+        if not name:
+            continue
+        condition = dep.get("condition", "")
+        # Only enforce on deps that gate on `<name>.enabled`. Deps with
+        # no condition load unconditionally by design (and so don't need
+        # the default); deps with a different condition path use that
+        # path's default.
+        if condition and condition != f"{name}.enabled":
+            # Different gating path — skip this enforcement.
+            continue
+
+        block = values.get(name)
+        if block is None:
+            missing.append((name, "block missing entirely"))
+            continue
+        if not isinstance(block, dict):
+            wrong_type.append((name, type(block).__name__))
+            continue
+        if "enabled" not in block:
+            missing.append((name, f"`{name}.enabled` key missing"))
+            continue
+
+    if missing or wrong_type:
+        sys.stderr.write(
+            "FAIL: chart dependencies without an `<name>.enabled` default in "
+            "values.yaml.\n"
+            "Helm's `condition:` is a no-op when the path is missing — the "
+            "dep loads unconditionally\n"
+            "on every install. See SPEC.md BEHAVIOR/dep-defaults-presence.\n\n"
+        )
+        for name, why in missing:
+            sys.stderr.write(f"  {name}: {why}\n")
+        for name, t in wrong_type:
+            sys.stderr.write(
+                f"  {name}: top-level value is {t}, expected map with `enabled` key\n"
+            )
+        sys.stderr.write(
+            "\nFix: add the missing default block(s) in library-chart/values.yaml:\n"
+        )
+        for name, _ in missing:
+            sys.stderr.write(f"  {name}:\n    enabled: false\n")
+        return 1
+
+    print(f"OK: all {len(deps)} dependencies have `<name>.enabled` defaults in values.yaml")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/library-chart/tests/dep-defaults-presence/run.sh
+++ b/library-chart/tests/dep-defaults-presence/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Assert every Chart.yaml dep gates on `<name>.enabled` and has a
+# matching default in values.yaml. See check.py for the rationale and
+# SPEC.md BEHAVIOR/dep-defaults-presence for the canonical contract.
+#
+# Usage: ./run.sh
+# Requires: python3 + PyYAML.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+python3 "$SCRIPT_DIR/check.py"
+exit $?

--- a/library-chart/tests/services-iteration-grep/check.py
+++ b/library-chart/tests/services-iteration-grep/check.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Assert that every chart template iterates services[] via the
+`enabledServices` helper, not raw `.Values.services`.
+
+Why: see SPEC.md BEHAVIOR/services-iteration. Drift between consumer
+templates (binding-secret.yaml using enabledServices but deployment.yaml
+using raw .Values.services) caused a real runtime bug at 0.11.9 — a
+disabled service's pod tried to mount a Secret the binding-secret
+template never rendered.
+
+This test greps every `library-chart/templates/*.yaml` file for
+`range .* .Values.services`. A match WITHOUT an `enabledServices`
+declaration in scope upstream fails the test with file:line pointers.
+
+Layout: same as the other library-chart/tests/* (run.sh + check.py).
+"""
+import os
+import re
+import sys
+
+
+# Pattern matching: `{{- range $i, $svc := .Values.services }}` and
+# variants (different whitespace, different loop variable names).
+RANGE_RAW_PATTERN = re.compile(
+    r"range\s+(?:\$\w+\s*,\s*)?\$\w+\s*:=\s*\.Values\.services\b"
+)
+ENABLED_PATTERN = re.compile(
+    r'\$\w+\s*:=\s*include\s+"suse-library\.dsl\.enabledServices"'
+)
+
+
+def main() -> int:
+    here = os.path.dirname(os.path.abspath(__file__))
+    templates_dir = os.path.abspath(
+        os.path.join(here, "..", "..", "templates")
+    )
+
+    if not os.path.isdir(templates_dir):
+        sys.stderr.write(f"FAIL: missing templates dir at {templates_dir}\n")
+        return 1
+
+    failures = []
+
+    # Only check `.yaml` chart templates. `.tpl` files (helper definitions)
+    # ARE the place where the raw `.Values.services` iteration legitimately
+    # lives — the `enabledServices` helper itself walks the raw list to
+    # filter it. The invariant is for the consumer side: every chart
+    # template that emits resources must go through enabledServices.
+    for entry in sorted(os.listdir(templates_dir)):
+        if not entry.endswith(".yaml"):
+            continue
+        path = os.path.join(templates_dir, entry)
+        with open(path) as f:
+            content = f.read()
+
+        # Track whether an `$enabled := include "...enabledServices..."` has
+        # been declared in the file before each raw-services match.
+        # Simple heuristic: walk line by line, set a flag when the helper
+        # declaration is seen, flag any raw-services match seen before that
+        # OR with the helper out of scope.
+        #
+        # This is a conservative grep — it doesn't model Helm's full
+        # variable scoping. It catches the common case (file-level decl
+        # followed by sibling ranges) which is the pattern we want to
+        # enforce. False positives can be fixed by hoisting the
+        # declaration; false negatives would require deliberate
+        # circumvention (declaring `$enabled` then ignoring it).
+        enabled_seen = False
+        for lineno, line in enumerate(content.splitlines(), start=1):
+            if ENABLED_PATTERN.search(line):
+                enabled_seen = True
+                continue
+            if RANGE_RAW_PATTERN.search(line):
+                if not enabled_seen:
+                    failures.append(
+                        f"{path}:{lineno}: raw `.Values.services` iteration "
+                        "without an `$enabled := include "
+                        '"suse-library.dsl.enabledServices"` declared above. '
+                        "See SPEC.md BEHAVIOR/services-iteration."
+                    )
+
+    if failures:
+        sys.stderr.write(
+            "FAIL: chart template(s) iterate raw `.Values.services` instead "
+            "of the enabledServices helper. This breaks the\n"
+            "services-iteration invariant — a disabled service ends up "
+            "referenced by some templates but not others, and pods stick\n"
+            "in pending with confusing MountVolume errors.\n\n"
+        )
+        for line in failures:
+            sys.stderr.write(f"  {line}\n")
+        sys.stderr.write(
+            "\nFix: hoist `$enabled := include "
+            '"suse-library.dsl.enabledServices" $ | fromJsonArray` near\n'
+            "the top of the template, then `range $i, $svc := $enabled` "
+            "everywhere.\n"
+        )
+        return 1
+
+    print("OK: every services[] iteration uses the enabledServices helper")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/library-chart/tests/services-iteration-grep/run.sh
+++ b/library-chart/tests/services-iteration-grep/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Assert services[] iteration goes through enabledServices in every
+# template. See check.py for the long-form rationale and SPEC.md
+# BEHAVIOR/services-iteration for the canonical contract.
+#
+# Usage: ./run.sh
+# Requires: python3 (no PyYAML — pure regex grep).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+python3 "$SCRIPT_DIR/check.py"
+exit $?

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.10
+  version: 0.11.11
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-nodejs/chart/Chart.yaml
+++ b/templates/web-nodejs/chart/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [rda, {{ .Language }}]
 
 dependencies:
   - name: suse-library
-    version: 0.11.10
+    version: 0.11.11
     # Vendored at charts/suse-library/. The library chart references
     # AppCo charts by their real name (postgresql, prometheus, grafana,
     # ...) — toggle each one via suse-library.<chart>.enabled in


### PR DESCRIPTION
User asked how to apply PCD to the library. Phase 1: SPEC.md captures the existing implicit contracts (services-iteration, dep-defaults-presence, manifest-version-sync, etc.); two new tests lock in the recent fixes (deployment iterates enabledServices, every dep has a values default); CONTRIBUTING.md mandates SPEC.md updates with a per-bug-class checklist. LESSONS postscript anchors each rule to the live bug that motivated it. Phase 2 (binding-secret-schema test, tilt-ext test fixture, render corner cases) follows.