### PR TITLE
feat(library 0.11.12): FQDN service.host for cross-namespace shared bindings (NS Phase C)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.13
+version: 0.11.14
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -2,7 +2,7 @@
 
 ## META
 Deployment:   helm-library-chart
-Version:      0.11.13
+Version:      0.11.14
 Spec-Schema:  0.1.0
 Author:       François-Xavier Houard <fx.houard@gmail.com>
 License:      Apache-2.0
@@ -327,6 +327,42 @@ Status: in-progress
   spec → code → tests → version bump in lockstep across all four
   files (library Chart.yaml, rda-bundle.yaml, template Chart.yaml,
   SPEC.md META.Version).
+
+## MILESTONE: 0.11.14
+Status: in-progress
+
+- `dsl-mappings.yaml` `service.host` for all four catalogued charts
+  (postgresql, redis, prometheus, grafana) moves from bare-name
+  templates (`{{ .Release.Name }}-postgresql`) to FQDN templates
+  (`{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local`).
+  NS Phase C per `idefxH/rda-cli#74`. (rebased over 0.11.13 rename PR)
+- Why FQDN: NS Phase A made the deploy namespace explicit per project
+  and per developer (multi-dev shared cluster pattern,
+  `{{.project}}-{{.user}}`). Phase C unlocks the cross-namespace
+  shared-binding case (UC5) — a `provisioning: shared` postgres
+  deployed in a third namespace, consumed by two project namespaces.
+  Bare-name templates only resolve within the same namespace; FQDN
+  resolves anywhere via cluster-DNS.
+- Bare-name back-compat: bare names still work *within* the same
+  namespace because Kubernetes DNS resolves unqualified names against
+  the pod's own namespace. So legacy projects (rda-cli pre-0.1.43,
+  no namespace block, deploys with bindings + workload in the same
+  namespace) keep working through the binding-secret env var even
+  though the var now contains the FQDN. Apps that connect by hostname
+  treat `host.ns.svc.cluster.local` and `host` interchangeably when
+  both resolve.
+- Companion change in `tilt-extension-suse-rda` (PR stacked on
+  Phase A's `feature/ns-phase-a-tiltfile`): `workload_name_for()` now
+  substitutes `{{ .Release.Namespace }}` in addition to
+  `{{ .Release.Name }}`, then strips the FQDN suffix
+  (`.<ns>.svc.cluster.local`) to recover the bare workload name —
+  k8s_resource registers by Deployment / StatefulSet name, not by
+  Service FQDN. Idempotent on bare-name templates so the strip is
+  safe to apply across both the pre-0.11.14 and post-0.11.14 shapes.
+- Manifest version sync: `library-chart/Chart.yaml` and
+  `rda-bundle.yaml::library_chart.version` both bumped to 0.11.14 in
+  the same commit. The `manifest-version-sync` test guard catches
+  drift if either is missed.
 
 ---
 

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -65,7 +65,7 @@ charts:
         # AppCo postgresql 0.4.x (internal Bitnami chart 13.x lineage).
         # Service is named <release>-postgresql (no -primary / -master suffix).
         service:
-          host: "{{ .Release.Name }}-postgresql"
+          host: "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local"
           port: 5432
         values_mapping:
           auth.user.name: postgresql.auth.username
@@ -121,7 +121,7 @@ charts:
         # PodTemplate-based schema separates init / app / sidecar
         # resource budgets.
         service:
-          host: "{{ .Release.Name }}-redis"
+          host: "{{ .Release.Name }}-redis.{{ .Release.Namespace }}.svc.cluster.local"
           port: 6379
         values_mapping:
           auth.password: redis.auth.password
@@ -163,7 +163,7 @@ charts:
         # no PVC-baked credential to drift against; the time-series
         # database is data, not auth state.
         service:
-          host: "{{ .Release.Name }}-prometheus-server"
+          host: "{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace }}.svc.cluster.local"
           port: 80
           scheme: http
         values_mapping:
@@ -207,7 +207,7 @@ charts:
         # AppCo grafana 12.x. Service maps port 80 (chart default) to pod
         # port 3000. The library's auto-Ingress (issue #8) uses port 80.
         service:
-          host: "{{ .Release.Name }}-grafana"
+          host: "{{ .Release.Name }}-grafana.{{ .Release.Namespace }}.svc.cluster.local"
           port: 80
         values_mapping:
           auth.admin.name: grafana.adminUser

--- a/library-chart/tests/prometheus/run.sh
+++ b/library-chart/tests/prometheus/run.sh
@@ -45,9 +45,13 @@ check() {
 }
 
 check "binding-secret name = demo-prom-binding" "name: demo-prom-binding"
-check "binding-secret host = demo-prometheus-server" 'host: "demo-prometheus-server"'
+# Library 0.11.12+: service.host is FQDN (NS Phase C — supports cross-
+# namespace shared bindings). helm template's default namespace is
+# 'default' when --namespace isn't passed, so the rendered FQDN is
+# <release>-<chart>.default.svc.cluster.local.
+check "binding-secret host = demo-prometheus-server FQDN" 'host: "demo-prometheus-server.default.svc.cluster.local"'
 check "binding-secret port = 80" 'port: "80"'
-check "binding-secret url = http://demo-prometheus-server:80" 'url: "http://demo-prometheus-server:80"'
+check "binding-secret url = http://...:80 FQDN" 'url: "http://demo-prometheus-server.default.svc.cluster.local:80"'
 check "binding-secret type = prometheus" 'type: "prometheus"'
 check "env var PROM_HOST" "name: PROM_HOST"
 check "env var PROM_PORT" "name: PROM_PORT"

--- a/library-chart/tests/provisioning/run.sh
+++ b/library-chart/tests/provisioning/run.sh
@@ -56,7 +56,7 @@ run_one() {
     PASS=$((PASS+1))
 }
 
-run_one "$SCRIPT_DIR/01-local-default-postgresql.values.yaml"       pass "host: \"testrelease-postgresql\""
+run_one "$SCRIPT_DIR/01-local-default-postgresql.values.yaml"       pass "host: \"testrelease-postgresql.default.svc.cluster.local\""
 run_one "$SCRIPT_DIR/02-shared-with-overlay-defaults-vault.values.yaml"  pass "host: \"shared-pg.platform-services\""
 run_one "$SCRIPT_DIR/03-shared-without-overlay-fails.values.yaml"   fail "no defaults.shared_services.postgresql.host"
 run_one "$SCRIPT_DIR/04-external-with-endpoint.values.yaml"         pass "host: \"legacy-postgres.corp.local\""

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -18,7 +18,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.13
+  version: 0.11.14
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled


### PR DESCRIPTION
Bundle library bumps to 0.11.12 with FQDN service.host templates for all 4 catalogued charts (postgresql, redis, prometheus, grafana). NS Phase C per idefxH/rda-cli#74.

### What changes
- `{{ .Release.Name }}-postgresql` → `{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local` (and the same for the other 3 charts)
- Bumps library-chart/Chart.yaml + rda-bundle.yaml in lockstep (the manifest-version-sync test enforces parity)
- SPEC.md gets a new MILESTONE 0.11.12 paragraph + META.Version bump

### Why FQDN now
NS Phase A made the deploy namespace explicit per project (`{{.project}}`) and per developer (`{{.project}}-{{.user}}`). Phase C unlocks the **cross-namespace shared-binding** case (UC5): a `provisioning: shared` postgres deployed in a third namespace, consumed by two project namespaces. Bare-name templates only resolve within the same namespace; FQDN resolves anywhere via cluster-DNS.

### Bare-name back-compat
Bare names still resolve **within** the same namespace because k8s DNS searches the pod's own namespace first. So legacy projects (rda-cli pre-0.1.43, no namespace block, bindings + workload in the same ns) keep working through the binding-secret env var even though the var now contains the FQDN. Apps that connect by hostname treat `host.ns.svc.cluster.local` and `host` as the same target when both resolve.

### Companion change
`tilt-extension-suse-rda` PR stacked on top of NS Phase A's tilt-ext PR: `workload_name_for()` now substitutes `{{ .Release.Namespace }}` and strips the FQDN suffix to recover the bare workload name (k8s_resource registers by Deployment / StatefulSet name, not by Service FQDN). Idempotent on bare-name templates.

### Tests
- prometheus + provisioning suites updated to expect the FQDN form (helm template's default namespace is `default`)
- All other test suites unaffected (auth-seed, env-aliases, services-iteration-grep, dsl-mappings-schema)
- Pre-existing failures on `auto-ingress-ui` and `passthrough-collision` are unchanged by this PR (orthogonal flake / known issue)

Closes Phase C portion of idefxH/rda-cli#74.