### PR TITLE
test(provisioning): cross-namespace shared binding via FQDN (NS Phase D)

### DIFF
--- a/library-chart/tests/provisioning/09-shared-cross-namespace-fqdn.values.yaml
+++ b/library-chart/tests/provisioning/09-shared-cross-namespace-fqdn.values.yaml
@@ -1,0 +1,28 @@
+# UC5 (NS Phase D): shared postgres deployed in a third namespace
+# (`platform-services`), consumed by a project deployed elsewhere (e.g.
+# `payments` or `orders`). The corp overlay's defaults.shared_services
+# entry MUST carry the FQDN form for cross-namespace DNS resolution to
+# succeed — bare names only resolve within the consumer pod's own
+# namespace, which would break the cross-ns case.
+#
+# This fixture asserts the binding-secret's `host` key is the literal
+# FQDN string the overlay supplied. The library helper `bindingSecretFrom`
+# reads from `defaults.shared_services.<type>.host` verbatim — it doesn't
+# rewrite, doesn't infer, doesn't append a suffix. That's the contract:
+# whatever shape the operator wrote in the overlay is what the consumer
+# sees in the env var.
+defaults:
+  shared_services:
+    postgresql:
+      host: shared-pg-platform-services.platform-services.svc.cluster.local
+      port: 5432
+      scheme: tcp
+services:
+  - binding: shared-events-db
+    type: postgresql
+    provisioning: shared
+    auth:
+      user:
+        name: app
+        password: ignored
+        database: ignored

--- a/library-chart/tests/provisioning/run.sh
+++ b/library-chart/tests/provisioning/run.sh
@@ -64,6 +64,7 @@ run_one "$SCRIPT_DIR/05-external-missing-endpoint-fails.values.yaml"  fail "requ
 run_one "$SCRIPT_DIR/06-bad-provisioning-value-fails.values.yaml"   fail "must be 'local', 'shared', or 'external'"
 run_one "$SCRIPT_DIR/07-grafana-shared-uses-overlay-scheme.values.yaml"  pass "https://grafana.platform-services:3000"
 run_one "$SCRIPT_DIR/08-passthrough-on-shared-is-skipped.values.yaml"   pass "host: \"pg.platform-services\""
+run_one "$SCRIPT_DIR/09-shared-cross-namespace-fqdn.values.yaml"        pass "host: \"shared-pg-platform-services.platform-services.svc.cluster.local\""
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Stacked on #84. Adds fixture + assertion exercising UC5 (shared postgres in a third namespace, consumed cross-ns). Pairs with idefxH/rda-docs#19.