### PR TITLE
fix: web-go Procfile-less, qualified import path, service.yaml dig+toJson, kafka -controller

### DIFF
--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -365,7 +365,7 @@ charts:
     versions:
       - constraint: ">=1.0.0 <2.0.0"
         # AppCo apache-kafka 1.x (KRaft mode, no zookeeper). Broker
-        # service is <release>-apache-kafka-broker on 9092 (PLAINTEXT).
+        # service is <release>-apache-kafka-controller on 9092 (PLAINTEXT).
         # SASL / TLS are configurable via passthrough — the DSL surface
         # for kafka stays minimal: connect string + topic-level auth
         # don't fit the simple user/password shape.
@@ -375,7 +375,7 @@ charts:
         # operator manages. Persistence (KRaft metadata + topic logs)
         # IS data, but it's not auth state.
         service:
-          host: "{{ .Release.Name }}-apache-kafka-broker.{{ .Release.Namespace }}.svc.cluster.local"
+          host: "{{ .Release.Name }}-apache-kafka-controller.{{ .Release.Namespace }}.svc.cluster.local"
           port: 9092
         values_mapping:
           persistence.enabled: apache-kafka.broker.persistence.enabled
@@ -384,10 +384,10 @@ charts:
         binding_secret:
           - {key: type, literal: apache-kafka, skip_env: true}
           - {key: provider, literal: rda-appco, skip_env: true}
-          - {key: host, template: "{{ .Release.Name }}-apache-kafka-broker"}
+          - {key: host, template: "{{ .Release.Name }}-apache-kafka-controller"}
           - {key: port, literal: "9092"}
           # bootstrap_servers is the kafka-client convention (same
           # shape as KAFKA_BOOTSTRAP_SERVERS in containerised confluent
           # / strimzi clients). Single broker, port 9092 — overrides
           # via passthrough for multi-broker / SASL setups.
-          - {key: bootstrap_servers, template: "{{ .Release.Name }}-apache-kafka-broker:9092"}
+          - {key: bootstrap_servers, template: "{{ .Release.Name }}-apache-kafka-controller:9092"}

--- a/library-chart/templates/service.yaml
+++ b/library-chart/templates/service.yaml
@@ -6,12 +6,18 @@
     Ingress also defaults off, but service-off is the rarer case
     (workers without inbound traffic). Bundle 0.11.16+.
 
-    `dig` walks an optional path through .Values; the third arg is the
-    fallback when any segment is missing. Equivalent to
+    `dig` walks an optional path; the third arg is the fallback when
+    any segment is missing. Equivalent to
     `(default true .Values.service.enabled)` but tolerates the whole
     `service:` block being absent (most projects don't write one).
+
+    `.Values | toJson | fromJson` round-trip coerces the chartutil.Values
+    wrapper down to `map[string]interface{}`, which `dig` requires.
+    Without the round-trip, dig errors with "interface conversion:
+    interface {} is common.Values, not map[string]interface {}".
+    Tested helm 3.17+; cheap (single chart's values, ~µs).
 */}}
-{{- if (dig "service" "enabled" true .Values) }}
+{{- if (dig "service" "enabled" true (.Values | toJson | fromJson)) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/templates/web-go/Procfile
+++ b/templates/web-go/Procfile
@@ -1,9 +1,0 @@
-# CNB Procfile — declares the launch processes that buildpacks register.
-#
-# - web: production launch (compiled binary at /app/app via Dockerfile).
-# - dev: development launch via `go run` against the source tree. Tilt's
-#   live-update sync writes new files into the dev container; `go run`
-#   recompiles on each invocation. Future iteration: pair with air or
-#   reflex for faster watcher-driven rebuilds.
-web: /app/app
-dev: go run ./...

--- a/templates/web-go/go.mod
+++ b/templates/web-go/go.mod
@@ -1,3 +1,3 @@
-module {{ .Name }}
+module example.com/{{ .Name }}
 
 go 1.22


### PR DESCRIPTION
Follow-ups discovered while running e2e scenarios 08-11 after the original 0.11.16 PR merged:

- **library-chart/templates/service.yaml** — `dig` doesn't work on `chartutil.Values` (panics with "interface conversion: interface {} is common.Values, not map[string]interface {}"). Round-trip via `(.Values | toJson | fromJson)` coerces to plain `map[string]interface{}`. Tested helm 3.17+.

- **library-chart/dsl-mappings.yaml** — Apache Kafka workload is `<release>-apache-kafka-controller` (chart 1.3 KRaft mode), not `-broker`. service.host + binding-secret host template + bootstrap_servers all corrected.

- **templates/web-go/go.mod** — heroku/go buildpack rejects unqualified module names with "Invalid Go package import path". Switched to `module example.com/{{ .Name }}` (rfc-style import path).

- **templates/web-go/Procfile** — DELETED. heroku/go skips launch-process registration when a Procfile is present ("Procfile detected"). Without it, heroku/go auto-registers `web` pointing at the absolute layer path `/layers/heroku_go/go_target/bin/<name>` — exactly what the CNB launcher needs.

Live verified: scenarios 07, 08, 09, 10, 11 all pass end-to-end after these fixes.

Co-authored-by: Claude <noreply@anthropic.com>