### PR TITLE
chore: bump tilt-extension pin to v0.3.1 (py<3.12 tarfile fix)

### DIFF
--- a/templates/web-go/Tiltfile
+++ b/templates/web-go/Tiltfile
@@ -12,7 +12,7 @@ v1alpha1.extension_repo(
     # on Tuesday silently picks up changes pushed Monday afternoon.
     # Bumping this line is an explicit, reviewable upgrade. Override
     # locally for testing by editing this file.
-    ref='v0.3.0',
+    ref='v0.3.1',
 )
 v1alpha1.extension(
     name='suse-rda',

--- a/templates/web-nodejs/Tiltfile
+++ b/templates/web-nodejs/Tiltfile
@@ -12,7 +12,7 @@ v1alpha1.extension_repo(
     # on Tuesday silently picks up changes pushed Monday afternoon.
     # Bumping this line is an explicit, reviewable upgrade. Override
     # locally for testing by editing this file.
-    ref='v0.3.0',
+    ref='v0.3.1',
 )
 v1alpha1.extension(
     name='suse-rda',

--- a/templates/worker-nodejs/Tiltfile
+++ b/templates/worker-nodejs/Tiltfile
@@ -12,7 +12,7 @@ v1alpha1.extension_repo(
     # on Tuesday silently picks up changes pushed Monday afternoon.
     # Bumping this line is an explicit, reviewable upgrade. Override
     # locally for testing by editing this file.
-    ref='v0.3.0',
+    ref='v0.3.1',
 )
 v1alpha1.extension(
     name='suse-rda',


### PR DESCRIPTION
Tilt extension v0.3.1 ships the py<3.12 tarfile.extractall compat fix (idefxH/tilt-extension-suse-rda#25). Bump the 3 template Tiltfiles to pick it up.