### PR TITLE
feat(catalog): minio + dex migrate to ports: shape (0.11.19)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.18
+version: 0.11.19
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -358,7 +358,15 @@ charts:
         # the connector list.
         service:
           host: "{{ .Release.Name }}-dex.{{ .Release.Namespace }}.svc.cluster.local"
-          port: 5556
+          ports:
+            # http is the OIDC issuer endpoint — discovery, /token,
+            # /authorize, /keys all live here. Apps' OIDC libraries
+            # read DEX_HOST / DEX_PORT / DEX_URL.
+            http: { port: 5556, scheme: http, primary: true }
+            # gRPC API — for dex-managing clients (CLI, admin tools).
+            # Off by default in the chart; flip via passthrough.grpc.
+            # Cross-binding refs see DEX_GRPC_PORT / DEX_GRPC_URL.
+            grpc: { port: 5557, scheme: tcp }
         values_mapping:
           # Issuer URL — the canonical "where this dex thinks it lives"
           # value baked into the OIDC discovery endpoint. Required to
@@ -637,7 +645,15 @@ charts:
         # for durable buckets).
         service:
           host: "{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc.cluster.local"
-          port: 9000
+          ports:
+            # S3 API — apps that use MinIO as object storage talk to
+            # this port. Primary, so MINIO_HOST / MINIO_PORT / MINIO_URL
+            # alias to the S3 endpoint by default (matching the
+            # AWS SDK / boto3 idiom of `endpoint_url=...`).
+            s3: { port: 9000, scheme: http, primary: true }
+            # Console — the web UI for browsing buckets, IAM, policies.
+            # Cross-binding refs see MINIO_CONSOLE_PORT / MINIO_CONSOLE_URL.
+            console: { port: 9001, scheme: http }
         values_mapping:
           auth.user.name: minio.rootUser
           auth.user.password: minio.rootPassword

--- a/library-chart/tests/dsl-mappings-schema/check.py
+++ b/library-chart/tests/dsl-mappings-schema/check.py
@@ -166,12 +166,42 @@ def check_service(errors, chart, vidx, svc):
     elif not isinstance(svc["host"], str) or not svc["host"]:
         err(errors, "charts.%s.versions[%d].service.host" % (chart, vidx),
             "must be a non-empty string")
-    if "port" not in svc:
+    # Port shape — two flavours, mutually exclusive:
+    #   A. legacy single-port:  service.port: <int>
+    #   B. multi-port:          service.ports: { <name>: { port: <int>, scheme?, primary?: bool }, ... }
+    has_port = "port" in svc
+    has_ports = "ports" in svc
+    if not has_port and not has_ports:
         err(errors, "charts.%s.versions[%d].service" % (chart, vidx),
-            "missing 'port'")
-    elif not isinstance(svc["port"], int):
-        err(errors, "charts.%s.versions[%d].service.port" % (chart, vidx),
-            "must be an integer, got %s" % type(svc["port"]).__name__)
+            "missing 'port' (legacy) or 'ports' (multi-port map)")
+    elif has_port and has_ports:
+        err(errors, "charts.%s.versions[%d].service" % (chart, vidx),
+            "cannot declare both 'port' and 'ports' — pick one shape")
+    elif has_port:
+        if not isinstance(svc["port"], int):
+            err(errors, "charts.%s.versions[%d].service.port" % (chart, vidx),
+                "must be an integer, got %s" % type(svc["port"]).__name__)
+    else:
+        ports = svc["ports"]
+        if not isinstance(ports, dict) or not ports:
+            err(errors, "charts.%s.versions[%d].service.ports" % (chart, vidx),
+                "must be a non-empty map of name → {port, scheme?, primary?}")
+        else:
+            primary_count = 0
+            for name, p in ports.items():
+                base = "charts.%s.versions[%d].service.ports.%s" % (chart, vidx, name)
+                if not isinstance(p, dict):
+                    err(errors, base, "must be a dict")
+                    continue
+                if "port" not in p:
+                    err(errors, base, "missing 'port'")
+                elif not isinstance(p["port"], int):
+                    err(errors, base + ".port", "must be an integer")
+                if p.get("primary") is True:
+                    primary_count += 1
+            if primary_count != 1:
+                err(errors, "charts.%s.versions[%d].service.ports" % (chart, vidx),
+                    "exactly one port must have 'primary: true' (got %d)" % primary_count)
 
 
 def check_version(errors, chart, vidx, ver):

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -40,7 +40,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.18
+  version: 0.11.19
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled


### PR DESCRIPTION
Validates the multi-port stack end-to-end with real charts.

## Changes

```yaml
# minio
service:
  host: "..."
  ports:
    s3:      { port: 9000, scheme: http, primary: true }
    console: { port: 9001, scheme: http }

# dex
service:
  host: "..."
  ports:
    http: { port: 5556, scheme: http, primary: true }
    grpc: { port: 5557, scheme: tcp }
```

Primary port keeps the canonical short aliases (`MINIO_HOST/PORT/URL` = S3, `DEX_HOST/PORT/URL` = HTTP issuer). Secondary ports accessible today via cross-binding refs (`${binding:minio.console_url}`); per-port env-var emission in the binding-secret helper is a follow-up.

## Schema validator update

`tests/dsl-mappings-schema/check.py` now accepts both shapes:
- `service.port: <int>` (legacy single-port)
- `service.ports: { <name>: { port, scheme?, primary?: bool } }` (multi-port)

Mutually exclusive. Exactly one port in the map must have `primary: true`.

## Companion

- bundle #94 (merged) — helper reads `service.ports`
- rda-cli #99 (merged) — cross-binding accessors for named ports

## Tests

All 6 library-chart checks pass. rda-cli's cross-binding tests pass against this bundle.