### PR TITLE
feat(helpers): emit per-port env vars in binding-secret (closes #91)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.19
+version: 0.11.20
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/_helpers.tpl
+++ b/library-chart/templates/_helpers.tpl
@@ -561,6 +561,32 @@ stringData:
   {{- end }}
   {{- end }}
 {{- end }}
+{{- /* Multi-port emission (bundle 0.11.20+, paired with rda-cli 0.1.52
+       service.ports spec). When the chart declares service.ports with
+       named entries, emit <port_name>_host / <port_name>_port /
+       <port_name>_url for EVERY port (primary included, for explicit
+       discoverability — a dev who sees MINIO_S3_HOST in env knows
+       what they're getting, vs MINIO_HOST aliasing to the same).
+
+       Only fires for provisioning=local: shared/external bindings
+       have a single endpoint per binding by definition (the overlay's
+       defaults.shared_services map carries one host/port pair, and
+       endpoint: in external mode is also a single triple). Named
+       ports are an in-cluster Service shape concept; they don't
+       generalise to remote endpoints. */ -}}
+{{- if eq $provisioning "local" -}}
+{{- $svcSpec := index $mapping "service" | default dict -}}
+{{- $ports := index $svcSpec "ports" | default dict -}}
+{{- if $ports -}}
+{{- range $portName, $p := $ports -}}
+{{- $pPort := (index $p "port" | default "") | toString -}}
+{{- $pScheme := index $p "scheme" | default "http" -}}
+  {{ $portName }}_host: {{ $host | quote }}
+  {{ $portName }}_port: {{ $pPort | quote }}
+  {{ $portName }}_url: {{ printf "%s://%s:%s" $pScheme $host $pPort | quote }}
+{{- end }}
+{{- end -}}
+{{- end }}
 {{- end -}}
 
 {{/* ──────────────────────────────────────────────────────────────────────

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -40,7 +40,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.19
+  version: 0.11.20
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled


### PR DESCRIPTION
Closes the multi-port story end-to-end (bundle #91).

## What

Per-port env var emission in the binding-secret stringData. For `service.ports` charts, EACH named port emits `<port_name>_host`, `<port_name>_port`, `<port_name>_url` keys (primary included for explicit discoverability).

## Example: minio (s3 primary + console)

```yaml
stringData:
  type:         minio
  host:         <release>-minio.<ns>.svc.cluster.local   # primary alias
  port:         '9000'
  url:          http://<release>-minio.<ns>:9000
  s3_host:      <release>-minio.<ns>.svc.cluster.local
  s3_port:      '9000'
  s3_url:       http://<release>-minio.<ns>:9000
  console_host: <release>-minio.<ns>.svc.cluster.local
  console_port: '9001'
  console_url:  http://<release>-minio.<ns>:9001
```

The app's `envFromBinding` projection auto-emits:
- `MINIO_HOST/PORT/URL` (short alias = S3, primary)
- `MINIO_S3_HOST/PORT/URL` (explicit)
- `MINIO_CONSOLE_HOST/PORT/URL` (secondary port)

## Scope

Only fires for `provisioning=local`. `shared`/`external` bindings have a single endpoint per binding by definition (overlay's `defaults.shared_services` or explicit `endpoint:` triple). Named ports are an in-cluster Service shape concept.

## Closes the multi-port story

- rda-cli 0.1.52 (#99): `service.ports` spec + cross-binding accessors
- bundle 0.11.18 (#94): `_helpers.tpl` reads `service.ports`
- bundle 0.11.19 (#95): minio + dex migrate to `ports:` shape
- **bundle 0.11.20 (this PR)**: per-port env-var emission

## Tests

All 6 library-chart checks pass.