### PR TITLE
feat(library): bootstrap-jobs.yaml template (0.11.21)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   semantic aliases for portable libraries (DB_HOST when a SQL chart
   is enabled).
 type: application
-version: 0.11.20
+version: 0.11.21
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/bootstrap-jobs.yaml
+++ b/library-chart/templates/bootstrap-jobs.yaml
@@ -1,0 +1,90 @@
+{{/*
+bootstrap-jobs.yaml — emit one Helm Job per services[].bootstrap.jobs[]
+entry, materialised in the overlay as suse-library.bootstrap_jobs[]
+by `rda render` (rda-cli #92).
+
+Each entry shape (cross-binding refs already resolved by render):
+
+  - binding: <binding>
+    type:    <chart-type>
+    job:
+      name:         <jobname>             # required
+      image:        <image:tag>           # required
+      env:          { KEY: value, ... }   # optional
+      command:      [ ... ]               # optional
+      args:         [ ... ]               # optional
+      runOnce:      <bool>                # optional, default true
+      timeout:      <duration>            # optional, default 5m
+      backoffLimit: <int>                 # optional, default 3
+      restartPolicy: Never|OnFailure      # optional, default Never
+
+Hooks:
+  - helm.sh/hook: post-install,post-upgrade — runs after binding-secret
+    + deployment + sub-charts are ready (the dev's app pod doesn't
+    block on this; the Job runs alongside).
+  - helm.sh/hook-weight: 5 — gives a stable order if multiple bootstrap
+    jobs across bindings exist.
+  - helm.sh/hook-delete-policy: before-hook-creation — Helm deletes the
+    previous Job before creating a new one on upgrade.
+
+The Job's name is <release>-<binding>-<jobname>. Add a discriminator
+suffix if your project has two jobs with the same `name` across
+bindings.
+*/}}
+{{- range $idx, $entry := .Values.bootstrap_jobs }}
+{{- $binding := $entry.binding }}
+{{- $job := $entry.job }}
+{{- $jobName := $job.name | required (printf "bootstrap_jobs[%d].job.name is required" $idx) }}
+{{- $image := $job.image | required (printf "bootstrap_jobs[%d].job.image is required" $idx) }}
+{{- $name := printf "%s-%s-%s" $.Release.Name $binding $jobName }}
+{{- $backoffLimit := $job.backoffLimit | default 3 }}
+{{- $restartPolicy := $job.restartPolicy | default "Never" }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "suse-library.labels" $ | nindent 4 }}
+    rda.suse.com/bootstrap-job: "true"
+    rda.suse.com/bootstrap-binding: {{ $binding | quote }}
+    rda.suse.com/bootstrap-type: {{ $entry.type | quote }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation
+    rda.suse.com/source: "services[binding={{ $binding }}].bootstrap.jobs[name={{ $jobName }}]"
+spec:
+  backoffLimit: {{ $backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "suse-library.selectorLabels" $ | nindent 8 }}
+        rda.suse.com/bootstrap-job: "true"
+        rda.suse.com/bootstrap-binding: {{ $binding | quote }}
+    spec:
+      restartPolicy: {{ $restartPolicy }}
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ $jobName }}
+          image: {{ $image | quote }}
+          imagePullPolicy: IfNotPresent
+          {{- with $job.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $job.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $job.env }}
+          env:
+            {{- range $k, $v := . }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- end }}
+{{- end }}

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -40,7 +40,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.20
+  version: 0.11.21
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled


### PR DESCRIPTION
Pairs with [rda-cli #100](https://github.com/idefxH/rda-cli/pull/100). Iterates the overlay's `suse-library.bootstrap_jobs[]` list (rendered by rda-cli) and emits one Helm Job per entry.

## Hooks

```
helm.sh/hook: post-install,post-upgrade
helm.sh/hook-weight: '5'
helm.sh/hook-delete-policy: before-hook-creation
```

Job name: `<release>-<binding>-<jobname>`. Cross-binding refs in env / command / args have already been resolved by rda-cli at render time, so the template stays simple.

Labels carry `rda.suse.com/bootstrap-{job,binding,type}` for kubectl filtering.

## Smoke test

```bash
helm template /tmp/test library-chart \
  --set 'bootstrap_jobs[0].binding=db' \
  --set 'bootstrap_jobs[0].type=postgresql' \
  --set 'bootstrap_jobs[0].job.name=migrate' \
  --set 'bootstrap_jobs[0].job.image=ghcr.io/myorg/payments:flyway' \
  --show-only templates/bootstrap-jobs.yaml
```

(Requires `helm dependency update` first because of the parent chart's deps.)

## Tests

All 6 library-chart checks pass.