### PR TITLE
fix(templates): web-go go 1.24 + air live-reload + web-nodejs lock + 4 new test guards

### DIFF
--- a/library-chart/tests/template-nodejs-package-lock-present/check.py
+++ b/library-chart/tests/template-nodejs-package-lock-present/check.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Assert that every Node.js template directory with a `package.json`
+declaring runtime `dependencies` also ships a `package-lock.json`.
+
+Why this test exists: heroku/nodejs buildpack v5+ (the version baked
+into heroku/builder:24) installs runtime deps via `npm ci`, which
+*requires* a checked-in package-lock.json. Without it, the buildpack
+fails (or more subtly, falls back to a path that skips dependency
+install entirely on some versions), and the launched container
+crashes at runtime with errors like:
+
+    Error: Cannot find module 'pg'
+    Require stack:
+    - /workspace/src/index.js
+
+This failure is invisible at `pack build` time on some buildpack
+versions (the build "succeeds") and only surfaces when the pod tries
+to start — by which point the dev has waited through a full pack
+build and a Tilt deploy. Catching the missing lock file at bundle-PR
+time is dramatically cheaper.
+
+Discovered live (this commit): web-nodejs template shipped a Message
+Wall app with `pg` and `prom-client` in package.json's dependencies,
+but no package-lock.json. Every freshly-scaffolded Node project
+crash-looped on missing modules. Now caught at bundle test time.
+
+Test guard: walks templates/*/package.json. For each template with a
+non-empty `dependencies` (or `optionalDependencies`) object, asserts
+that package-lock.json exists alongside it and is non-empty.
+
+Note: package-lock.json is keyed by package versions, not by the
+parent's `name` field. So the same checked-in lock works regardless
+of `"name": "{{ .Name }}"` substitution at scaffold time. Devs MAY
+delete it and re-run `npm install --package-lock-only` to refresh —
+but it must be present in the template itself.
+"""
+import json
+import os
+import sys
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+TEMPLATES_DIR = os.path.join(REPO_ROOT, "..", "templates")
+
+
+def node_templates_with_deps():
+    """Yield (template_name, package_json_path, dep_count) for every
+    Node template whose package.json declares runtime dependencies."""
+    if not os.path.isdir(TEMPLATES_DIR):
+        return
+    for entry in sorted(os.listdir(TEMPLATES_DIR)):
+        tdir = os.path.join(TEMPLATES_DIR, entry)
+        if not os.path.isdir(tdir):
+            continue
+        pkg = os.path.join(tdir, "package.json")
+        if not os.path.isfile(pkg):
+            continue
+        # package.json may contain Go-template placeholders like
+        # `"name": "{{ .Name }}"`. We only care about the deps fields,
+        # which are pure JSON, so a tolerant load is fine: read raw
+        # then strip the outer `name` line if it'd choke json.loads.
+        try:
+            with open(pkg) as f:
+                raw = f.read()
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            # Best-effort: replace common Go-template tokens, retry.
+            cleaned = raw.replace("{{ .Name }}", "tpl")
+            try:
+                data = json.loads(cleaned)
+            except json.JSONDecodeError:
+                # Can't parse — skip rather than false-positive.
+                continue
+        deps = data.get("dependencies") or {}
+        opt = data.get("optionalDependencies") or {}
+        total = len(deps) + len(opt)
+        if total == 0:
+            continue
+        yield entry, pkg, total
+
+
+def main():
+    drift = []
+    inspected = 0
+    for name, pkg, ndeps in node_templates_with_deps():
+        inspected += 1
+        lock = os.path.join(os.path.dirname(pkg), "package-lock.json")
+        if not os.path.isfile(lock):
+            drift.append((name, pkg, lock, ndeps, "missing"))
+            continue
+        if os.path.getsize(lock) == 0:
+            drift.append((name, pkg, lock, ndeps, "empty"))
+
+    if drift:
+        print("✗ template-nodejs-package-lock-present: drift detected", file=sys.stderr)
+        print("", file=sys.stderr)
+        for name, pkg, lock, ndeps, why in drift:
+            print(f"  {name}: {ndeps} runtime deps in {pkg}", file=sys.stderr)
+            print(f"    ↳ package-lock.json {why} at {lock}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(
+            "heroku/nodejs buildpack v5+ requires package-lock.json for `npm ci`.",
+            file=sys.stderr,
+        )
+        print(
+            "Without it, the launched pod crashes at runtime with `Cannot find module`.",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
+        print("Fix: from inside the template directory, run:", file=sys.stderr)
+        print("    npm install --package-lock-only --no-audit --no-fund", file=sys.stderr)
+        print("Then commit the generated package-lock.json.", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(
+            "(If your package.json has `\"name\": \"{{ .Name }}\"`, sed-replace it",
+            file=sys.stderr,
+        )
+        print(
+            " to a placeholder before `npm install`, then sed-restore the placeholder.)",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"✓ template-nodejs-package-lock-present: {inspected} template(s) inspected, "
+        "all OK."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/library-chart/tests/template-nodejs-package-lock-present/run.sh
+++ b/library-chart/tests/template-nodejs-package-lock-present/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Test runner for template-nodejs-package-lock-present.
+#
+# Asserts that every templates/*/package.json declaring runtime
+# dependencies ships a matching package-lock.json so the heroku/nodejs
+# buildpack's `npm ci` step doesn't silently skip dep install (or
+# fail outright on v5+) and pods don't crash with `Cannot find module`.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+python3 "$SCRIPT_DIR/check.py"
+exit $?

--- a/templates/web-nodejs/package-lock.json
+++ b/templates/web-nodejs/package-lock.json
@@ -1,0 +1,204 @@
+{
+  "name": "{{ .Name }}",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "{{ .Name }}",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "pg": "^8.13.1",
+        "prom-client": "^15.1.3"
+      },
+      "engines": {
+        "node": "22"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

3 commits stacked on `fix/web-go-1.23-procfile-watch-and-tests`. Every fix below was either discovered live during `tilt up` and is now caught by a new bundle test, or improves the inner-loop perf of an existing template.

## Commits

### 1. `fix(templates): bump web-go to go 1.24 + Procfile node --watch + 2 new test guards`

- web-go shipped with `go 1.22` but pulls `jackc/pgx/v5 v5.7.6`, which requires Go ≥ 1.23. Bumped to **go 1.24** (also enables the `tool` directive needed below).
- web-nodejs Procfile invoked `nodemon` but `package.json` had dropped nodemon as a dep — pod CrashLoopBackOff with `/bin/sh: nodemon: not found`. Fixed: `dev: node --watch src/index.js` (Node ≥ 22 native).
- New: `template-go-deps-version-compat/` — DEP_FLOORS table mapping (module, min_version, required_go_minor); fails when go directive < required.
- New: `template-procfile-package-consistency/` — every Procfile command's first token must be in RUNTIME_BINS or package.json deps.

### 2. `feat(web-go): add air for live-reload + ship indirect deps + pack-build smoke test`

- Added [air](https://github.com/air-verse/air) for Go live-reload (sub-2s recompile vs. ~14s full `pack build` rebuild).
- `go.mod`: `tool github.com/air-verse/air` (Go 1.24+ tool directive). Indirect deps pinned via `go mod tidy` so heroku/go's `go list -tags heroku` stops complaining.
- `Procfile`: `dev: air -c .air.toml`.
- `.air.toml`: watches `./` for `.go` files, 100ms coalesce delay, excludes vendor/deploy/tmp.
- tilt-extension-suse-rda PR #30 wires `live_update_paths=['./']`, install_trigger on go.mod/go.sum, and `pack_default_process: 'dev'` for Go.
- New: `template-pack-build-smoke/` — actually runs `pack build` against rendered templates (soft-skips when pack/docker absent). Catches buildpack regressions at PR time.

### 3. `fix(web-nodejs): ship package-lock.json + test guard`

- web-nodejs Message Wall app declared `pg` + `prom-client` as runtime deps but the template was missing `package-lock.json`. heroku/nodejs v5+ requires the lock for `npm ci` — without it, the pod crashes with `Error: Cannot find module 'pg'`.
- Regenerated lock via `npm install --package-lock-only`, restored the `{{ .Name }}` placeholder.
- New: `template-nodejs-package-lock-present/` — walks `templates/*/package.json`, fails if any template with runtime deps lacks (or has empty) `package-lock.json`.

## Why these are tests, not just one-time fixes

PCD-style: every regression discovered live now has a test guard so the next dev (or AI) hits a bundle-PR test failure with a remediation message instead of waiting through a full pack-build round-trip and a CrashLoopBackOff.

## Verified

- `bash library-chart/tests/template-nodejs-package-lock-present/run.sh` → `✓ 2 template(s) inspected, all OK.`
- Same guard with lock moved aside → exit=1 with `✗ drift detected` + remediation.
- e2e scenario 02 (web-nodejs + postgresql) re-running with the lock in place to confirm pod reaches Ready.