### PR TITLE
fix(binding-secret): preserve indent on first multi-port key (dex/minio)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.23
+version: 0.11.24
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/templates/_helpers.tpl
+++ b/library-chart/templates/_helpers.tpl
@@ -570,9 +570,9 @@ stringData:
 {{- $svcSpec := index $mapping "service" | default dict -}}
 {{- $ports := index $svcSpec "ports" | default dict -}}
 {{- if $ports -}}
-{{- range $portName, $p := $ports -}}
-{{- $pPort := (index $p "port" | default "") | toString -}}
-{{- $pScheme := index $p "scheme" | default "http" -}}
+{{- range $portName, $p := $ports }}
+{{- $pPort := (index $p "port" | default "") | toString }}
+{{- $pScheme := index $p "scheme" | default "http" }}
   {{ $portName }}_host: {{ $host | quote }}
   {{ $portName }}_port: {{ $pPort | quote }}
   {{ $portName }}_url: {{ printf "%s://%s:%s" $pScheme $host $pPort | quote }}

--- a/library-chart/tests/binding-secret-multiport-render/check.py
+++ b/library-chart/tests/binding-secret-multiport-render/check.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Regression: binding-secret.yaml renders valid YAML for multi-port
+charts (dex, minio, ...) and combinations thereof.
+
+Why this test exists: the helper's multi-port emission section had
+right-trim `-}}` on the per-iteration assignments, which stripped the
+trailing newline + indent. The first multi-port key (e.g. `http_host`)
+landed at column 0 instead of column 2, gluing onto the previous
+line's value:
+
+    issuer: "http://app-dex:5556"http_host: "..."
+                                ^^^ glued, YAML parse fails
+                                    line 25: did not find expected key
+
+For postgresql (single-port, no `service.ports` block) the code path
+was skipped; the bug only fired when at least one of the enabled
+bindings declared `service.ports` in dsl-mappings.yaml. This made the
+e2e suite's single-binding scenarios pass while combined ones blew up.
+
+Discovered live: scenario 15-fullstack-postgres-dex-liveupdate failed
+its first `helm template` step on every run with the multi-port path
+indentation bug.
+
+Test guard: render the bundled example chart with a values overlay
+that activates BOTH a single-port (postgresql) and a multi-port (dex)
+binding, then run `helm template` and verify:
+  1. helm template exit=0
+  2. the rendered binding-secret YAML parses as valid YAML
+  3. no `<port_name>_host:` key has lost its 2-space indent
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+LIBRARY = os.path.join(REPO_ROOT)
+
+
+def have(cmd):
+    return shutil.which(cmd) is not None
+
+
+def main():
+    if not have("helm"):
+        print("⚠ helm not on PATH — soft-skip (test runs in CI w/ helm)")
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Mini-chart that depends on the local library-chart.
+        with open(os.path.join(tmp, "Chart.yaml"), "w") as f:
+            f.write(textwrap.dedent(f"""\
+                apiVersion: v2
+                name: bsec-multiport-test
+                version: 0.0.1
+                dependencies:
+                  - name: suse-library
+                    repository: file://{LIBRARY}
+                    version: ~0
+            """))
+        # Values: BOTH single-port (postgresql) and multi-port (dex).
+        with open(os.path.join(tmp, "values.yaml"), "w") as f:
+            f.write(textwrap.dedent("""\
+                suse-library:
+                  name: app
+                  port: 8080
+                  image:
+                    repository: app
+                    tag: dev
+                  imagePullSecrets:
+                    - name: application-collection
+                  services:
+                    - binding: db
+                      type: postgresql
+                      enabled: true
+                      auth:
+                        admin: { password: "x" }
+                        user: { password: "y", database: "z" }
+                    - binding: auth
+                      type: dex
+                      enabled: true
+                      issuer: "http://app-dex.app.svc.cluster.local:5556"
+                      passthrough:
+                        config:
+                          enablePasswordDB: true
+                          oauth2: { skipApprovalScreen: true }
+                          staticClients: []
+                          staticPasswords: []
+                          storage: { type: memory }
+            """))
+        # helm dep update — pulls the local library-chart into charts/.
+        try:
+            subprocess.run(
+                ["helm", "dependency", "update", tmp],
+                check=True, capture_output=True, text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print("✗ helm dependency update failed:", file=sys.stderr)
+            print(e.stderr, file=sys.stderr)
+            return 1
+
+        # Render binding-secret only.
+        proc = subprocess.run(
+            [
+                "helm", "template", "test", tmp,
+                "--namespace", "test",
+                "--show-only", "charts/suse-library/templates/binding-secret.yaml",
+            ],
+            capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            print("✗ helm template failed — binding-secret render is broken", file=sys.stderr)
+            print("--- stderr ---", file=sys.stderr)
+            print(proc.stderr, file=sys.stderr)
+            print("--- stdout ---", file=sys.stderr)
+            print(proc.stdout, file=sys.stderr)
+            return 1
+
+        rendered = proc.stdout
+
+        # 1. Parse as valid YAML.
+        try:
+            import yaml
+        except ImportError:
+            print("⚠ PyYAML not available — soft-skip parse check (CI has it)")
+            return 0
+
+        try:
+            docs = list(yaml.safe_load_all(rendered))
+        except yaml.YAMLError as e:
+            print("✗ rendered binding-secret.yaml is not valid YAML:", file=sys.stderr)
+            print(f"  {e}", file=sys.stderr)
+            print("--- rendered (first 60 lines) ---", file=sys.stderr)
+            for line in rendered.splitlines()[:60]:
+                print(f"  {line}", file=sys.stderr)
+            return 1
+
+        # 2. Indentation check: every multi-port `_host` / `_port` / `_url`
+        #    key in the rendered output must be indented by exactly 2 spaces
+        #    (i.e. live under `stringData:`). A mis-indented key would have
+        #    been glued to the previous line — caught above by yaml.safe_load
+        #    — but we add this explicit check so the failure message points
+        #    at the regression directly.
+        bad_indent = []
+        for ln, line in enumerate(rendered.splitlines(), 1):
+            stripped = line.lstrip()
+            for suffix in ("_host:", "_port:", "_url:"):
+                if stripped.startswith(("http", "grpc", "s3", "console", "tcp")) and suffix in stripped[:50]:
+                    indent = len(line) - len(stripped)
+                    if indent != 2:
+                        bad_indent.append((ln, indent, line))
+        if bad_indent:
+            print("✗ multi-port keys have wrong indentation (expected 2 spaces under stringData:):", file=sys.stderr)
+            for ln, ind, line in bad_indent:
+                print(f"  line {ln}: indent={ind} → {line!r}", file=sys.stderr)
+            return 1
+
+        # 3. Sanity: at least 2 Secrets emitted (db + auth).
+        secrets = [d for d in docs if d and d.get("kind") == "Secret"]
+        if len(secrets) < 2:
+            print(f"✗ expected ≥2 Secret docs, got {len(secrets)}", file=sys.stderr)
+            return 1
+
+        # 4. Sanity: the auth (dex) Secret has both `port` (primary) and
+        #    `http_port` / `grpc_port` (per-port).
+        auth = next((s for s in secrets if "auth-binding" in s["metadata"]["name"]), None)
+        if not auth:
+            print("✗ no auth-binding Secret in render", file=sys.stderr)
+            return 1
+        sd = auth.get("stringData", {})
+        for required in ("host", "port", "url", "issuer", "http_host", "http_port", "http_url",
+                         "grpc_host", "grpc_port", "grpc_url"):
+            if required not in sd:
+                print(f"✗ auth Secret missing key: {required}", file=sys.stderr)
+                print("    keys present:", sorted(sd.keys()), file=sys.stderr)
+                return 1
+
+        n = len(rendered.splitlines())
+        print(f"✓ binding-secret-multiport-render: {len(secrets)} Secrets, {n} lines, all keys indented + parseable.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/library-chart/tests/binding-secret-multiport-render/run.sh
+++ b/library-chart/tests/binding-secret-multiport-render/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Test runner for binding-secret-multiport-render.
+#
+# Asserts that helm template against suse-library renders a valid
+# binding-secret.yaml when BOTH a single-port (postgresql) and a
+# multi-port (dex) binding are enabled. Catches the multi-port
+# emission helper's right-trim indentation bug.
+#
+# Soft-skips when helm CLI / PyYAML are missing (no fixture box
+# inflicts a regression on the operator running tests on a fresh
+# clone with no helm installed).
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+python3 "$SCRIPT_DIR/check.py"
+exit $?


### PR DESCRIPTION
## Bug

`helm template` fails with `yaml: line 25: did not find expected key` whenever both a single-port AND a multi-port binding are enabled (e.g. postgresql `db` + dex `auth`). Single-binding scenarios slip past it because:

- single-port only (postgresql, redis, valkey, mariadb): `{{- if $ports -}}` skips the multi-port code path entirely.
- multi-port only (dex): the bug is still latent but the ordering of the surrounding text happens to leave it parseable in isolation.

Discovered live by **scenario 15-fullstack-postgres-dex-liveupdate** (rda-e2e-tests, this session): `tilt up` crashed at the very first `helm template` invocation. Trace:

```
Error: YAML parse error on app/charts/suse-library/templates/binding-secret.yaml:
error converting YAML to JSON: yaml: line 25: did not find expected key
```

## Root cause

`library-chart/templates/_helpers.tpl` → `suse-library.dsl.bindingSecretFrom` → multi-port emission (lines ~573-583). The per-iteration assignments had `-}}` right-trim:

```gotemplate
{{- range $portName, $p := $ports -}}
{{- $pPort := (index $p "port" | default "") | toString -}}
{{- $pScheme := index $p "scheme" | default "http" -}}
  {{ $portName }}_host: ...
```

Right-trim consumes ALL trailing whitespace — including the newline AND the leading 2 spaces of the next literal line. So `http_host: ...` lands at column 0 instead of column 2 of `stringData:`, gluing onto the previous quoted value:

```yaml
  issuer: "http://app-dex:5556"http_host: "..."
```

That's the YAML parse failure.

## Fix

Drop the trailing `-` from the three range-body assignments. With `}}` (no right-trim), the trailing newline + indent are preserved, and each iteration starts cleanly at column 2.

Each iteration now emits:

```yaml
  http_host: "..."
  http_port: "..."
  http_url: "..."
```

## Test

New `library-chart/tests/binding-secret-multiport-render/`:

1. Generates a mini-chart that depends on `suse-library` with BOTH postgresql `db` and dex `auth` bindings active.
2. Runs `helm template`, asserts exit=0.
3. Parses output via PyYAML, asserts valid YAML.
4. Asserts every `<port_name>_(host|port|url)` key is indented exactly 2 spaces.
5. Asserts both Secrets emit; auth Secret carries `host/port/url/issuer` + `http_*`/`grpc_*` per dsl-mappings dex `service.ports`.

Verified: passes after the fix; would fail (rc=1) on the buggy version.

## Bump

`library-chart` version 0.11.23 → 0.11.24.