### PR TITLE
feat(dex): pull from AppCo (dex-idp) via alias instead of upstream

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.24
+version: 0.11.25
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example
@@ -49,15 +49,30 @@ dependencies:
     version: "2.6.1-3.1"
     repository: oci://dp.apps.rancher.io/charts
     condition: redis.enabled
-  # dex/dex (OIDC + OAuth2) — upstream chart, not AppCo. The AppCo
-  # catalogue (as of 2026-04) does NOT include an OIDC IdP, so we pull
-  # from charts.dexidp.io directly. Same shape as the other deps:
-  # condition-gated by <chart>.enabled. The internal version aligns
-  # with the upstream tag for dexidp's chart, so the Tilt extension's
-  # _align_subchart_versions workaround is a no-op for this dep.
-  - name: dex
+  # dex (OIDC + OAuth2) via SUSE Application Collection.
+  #
+  #   - The upstream dex Helm chart at charts.dexidp.io is published
+  #     by the dex maintainers; AppCo packages the same chart as
+  #     `dex-idp` (chart name + scanned image). Switching to AppCo
+  #     gives us a single registry for everything (postgres, redis,
+  #     dex, ...) — no separate HTTP repo to bootstrap, image scanned
+  #     by SUSE, supported commercially.
+  #
+  #   - `alias: dex` keeps the on-disk dependency dir at
+  #     deploy/charts/dex/, and the chart's _helpers.tpl uses
+  #     `dex.fullname` (NOT `dex-idp.fullname` — checked in 0.24.0).
+  #     With the alias, .Chart.Name = "dex" inside the chart's
+  #     templates, so resource names stay <release>-dex (matching
+  #     dsl-mappings.yaml's service.host = {{ .Release.Name }}-dex).
+  #     User-facing values.yaml API is unchanged: still .dex.* under
+  #     suse-library: namespace.
+  #
+  # Internal version aligns with the upstream tag (AppCo follows
+  # upstream) so Tilt's _align_subchart_versions is a no-op.
+  - name: dex-idp
+    alias: dex
     version: "0.24.0"
-    repository: https://charts.dexidp.io
+    repository: oci://dp.apps.rancher.io/charts
     condition: dex.enabled
   - name: mariadb
     version: "0.1.7-10.1"

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -452,7 +452,7 @@ Status: in-progress
 
 - Catalogue gains a 5th chart: **dex** (OIDC + OAuth2 IdP). Unlike the
   4 prior charts, dex is NOT in the AppCo catalogue — pulled from the
-  upstream `https://charts.dexidp.io` repo at chart 0.24.0 (app 2.44.0).
+  AppCo `oci://dp.apps.rancher.io/charts/dex-idp` at chart 0.24.0 (app 2.44.0), aliased as `dex`.
   This is also the first chart in the catalogue with a non-OCI repo;
   helm dep update handles both shapes transparently.
 - `library-chart/dsl-mappings.yaml` gains a `dex:` entry:

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -338,9 +338,12 @@ charts:
   dex:
     versions:
       - constraint: ">=0.24.0 <1.0.0"
-        # Dex 0.24.0 (app 2.44.0). NOT in the AppCo catalogue — pulled
-        # from charts.dexidp.io (declared in library-chart/Chart.yaml
-        # with repository: https://charts.dexidp.io).
+        # Dex 0.24.0 (app 2.44.0) via SUSE Application Collection.
+        # Chart name on disk is `dex-idp` (AppCo's slug) but library
+        # Chart.yaml declares it with `alias: dex` so resource names,
+        # values keys, and helper Chart.Name all use "dex". User-
+        # facing API is unchanged from the upstream chart we pulled
+        # from charts.dexidp.io pre-0.11.25.
         #
         # Service: <release>-dex on port 5556 (HTTP issuer endpoint).
         # gRPC (5557) and HTTPS (5554) are off by default; flip via


### PR DESCRIPTION
## What

Replaces the upstream `https://charts.dexidp.io` HTTP repo with the SUSE Application Collection's OCI `dex-idp` chart. `alias: dex` in library Chart.yaml keeps everything backward-compatible.

## Before

```yaml
- name: dex
  version: "0.24.0"
  repository: https://charts.dexidp.io
  condition: dex.enabled
```

## After

```yaml
- name: dex-idp
  alias: dex
  version: "0.24.0"
  repository: oci://dp.apps.rancher.io/charts
  condition: dex.enabled
```

## Why

- Image scanned by SUSE: `dp.apps.rancher.io/containers/dex-idp:2.44.0-14.3` vs upstream's `docker.io/dexidp/dex`
- Single registry for the whole stack (no separate HTTP repo bootstrap, no log line `bootstrapped 1 HTTP helm repo(s): https://charts.dexidp.io` on every tilt up)
- Commercially supportable through SUSE channels
- Same upstream version (AppCo follows upstream)

## Why the alias works

AppCo's `dex-idp` chart kept its internal `_helpers.tpl` namespace as `dex` (verified at 0.24.0: helpers are `dex.fullname`, `dex.name`, `dex.labels`). With `alias: dex`:

- helm dep update writes `deploy/charts/dex/` (alias-named dir)
- `.Chart.Name = "dex"` inside the chart
- Resources named `<release>-dex` — matches dsl-mappings.yaml's `service.host = {{ .Release.Name }}-dex`
- User-facing values.yaml API unchanged: `.dex.*` under `suse-library:`

Zero migration friction for existing projects.

## Verified

```
helm dep update library-chart/
→ Pulled: dp.apps.rancher.io/charts/dex-idp:0.24.0

helm template testrelease ...
→ Service: name: testrelease-dex, ports: 5556 (http), 5558 (telemetry)
→ Labels: app.kubernetes.io/name: dex, helm.sh/chart: dex-0.24.0
```

binding-secret-multiport-render test guard already covers the multi-port path; renders unchanged.

## Bump

library-chart 0.11.24 → 0.11.25.