### PR TITLE
fix(templates): postgres optional — vanilla rda new + tilt up doesn't crash

### DIFF
--- a/templates/web-go/main.go
+++ b/templates/web-go/main.go
@@ -74,70 +74,78 @@ func main() {
 
 	port := envOrDefault("PORT", "8080")
 
+	// Postgres is OPTIONAL. If <DB_PREFIX>_HOST is unset (no postgres binding),
+	// the Message Wall API is disabled and the home page shows a friendly
+	// 'no DB bound' placeholder instead. /metrics, /health, /ready still
+	// work without postgres so the pod stays Ready.
 	host := envWithPrefix("HOST", "")
-	if host == "" {
-		log.Fatalf("💀 No %s_HOST in env — bind a postgresql service via deploy/values.yaml services[]", dbPrefix)
-	}
+	dbEnabled := host != ""
+	var db *sql.DB
+	if !dbEnabled {
+		log.Printf("ℹ️  No %s_HOST in env — postgres binding not configured; serving placeholder home page.", dbPrefix)
+		log.Printf("   To enable Message Wall: rda add-service postgresql %s, flip enabled:true, fill auth slots.", strings.ToLower(dbPrefix))
+	} else {
+		dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+			host,
+			envWithPrefix("PORT", "5432"),
+			envWithPrefix("USERNAME", ""),
+			envWithPrefix("PASSWORD", ""),
+			envWithPrefix("DATABASE", ""),
+		)
 
-	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
-		host,
-		envWithPrefix("PORT", "5432"),
-		envWithPrefix("USERNAME", ""),
-		envWithPrefix("PASSWORD", ""),
-		envWithPrefix("DATABASE", ""),
-	)
-
-	db, err := sql.Open("pgx", dsn)
-	if err != nil {
-		log.Fatalf("💀 sql.Open: %v", err)
-	}
-	defer db.Close()
-
-	// Retry the initial Ping — postgres often isn't Ready when the app
-	// pod starts (helm install kicks both in parallel; postgres init
-	// takes 5-15s). A Fatal exit here loops us in CrashLoop with k8s
-	// recreating us before postgres comes up. Retrying gives postgres
-	// time to finish init while we keep the process alive.
-	{
-		const maxAttempts = 60
-		const delay = 2 * time.Second
-		var lastErr error
-		for attempt := 1; attempt <= maxAttempts; attempt++ {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			err := db.PingContext(ctx)
-			cancel()
-			if err == nil {
-				lastErr = nil
-				break
-			}
-			lastErr = err
-			if attempt == maxAttempts {
-				break
-			}
-			log.Printf("⏳ postgres not ready yet (attempt %d/%d: %v); retrying in %s…",
-				attempt, maxAttempts, err, delay)
-			time.Sleep(delay)
+		var err error
+		db, err = sql.Open("pgx", dsn)
+		if err != nil {
+			log.Fatalf("💀 sql.Open: %v", err)
 		}
-		if lastErr != nil {
-			log.Fatalf("💀 db.Ping after %d attempts: %v", maxAttempts, lastErr)
+		defer db.Close()
+
+		// Retry the initial Ping — postgres often isn't Ready when the app
+		// pod starts (helm install kicks both in parallel; postgres init
+		// takes 5-15s). A Fatal exit here loops us in CrashLoop with k8s
+		// recreating us before postgres comes up. Retrying gives postgres
+		// time to finish init while we keep the process alive.
+		{
+			const maxAttempts = 60
+			const delay = 2 * time.Second
+			var lastErr error
+			for attempt := 1; attempt <= maxAttempts; attempt++ {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				err := db.PingContext(ctx)
+				cancel()
+				if err == nil {
+					lastErr = nil
+					break
+				}
+				lastErr = err
+				if attempt == maxAttempts {
+					break
+				}
+				log.Printf("⏳ postgres not ready yet (attempt %d/%d: %v); retrying in %s…",
+					attempt, maxAttempts, err, delay)
+				time.Sleep(delay)
+			}
+			if lastErr != nil {
+				log.Fatalf("💀 db.Ping after %d attempts: %v", maxAttempts, lastErr)
+			}
 		}
-	}
-	log.Printf("✅ Connected to PostgreSQL at %s:%s", host, envWithPrefix("PORT", "5432"))
+		log.Printf("✅ Connected to PostgreSQL at %s:%s", host, envWithPrefix("PORT", "5432"))
 
-	if _, err := db.Exec(`
-		CREATE TABLE IF NOT EXISTS messages (
-			id         SERIAL PRIMARY KEY,
-			body       TEXT NOT NULL CHECK (char_length(body) <= 280),
-			created_at TIMESTAMPTZ DEFAULT NOW()
-		)`); err != nil {
-		log.Fatalf("💀 create table: %v", err)
-	}
-	log.Printf("✅ Table ready")
+		if _, err := db.Exec(`
+			CREATE TABLE IF NOT EXISTS messages (
+				id         SERIAL PRIMARY KEY,
+				body       TEXT NOT NULL CHECK (char_length(body) <= 280),
+				created_at TIMESTAMPTZ DEFAULT NOW()
+			)`); err != nil {
+			log.Fatalf("💀 create table: %v", err)
+		}
+		log.Printf("✅ Table ready")
 
-	// Seed gauge with current count.
-	var initial int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&initial); err == nil {
-		messagesCurrent.Set(float64(initial))
+		// Seed gauge with current count.
+		var initial int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&initial); err == nil {
+			messagesCurrent.Set(float64(initial))
+		}
 	}
 
 	tpl := template.Must(template.New("page").Parse(htmlPage))
@@ -164,6 +172,11 @@ func main() {
 
 	mux.HandleFunc("/api/messages", func(w http.ResponseWriter, r *http.Request) {
 		t := time.Now()
+		if !dbEnabled {
+			http.Error(w, "messages api unavailable: no postgres binding configured (set services[].type=postgresql in deploy/values.yaml)", http.StatusServiceUnavailable)
+			observe(r.Method, "/api/messages", 503, t)
+			return
+		}
 		switch r.Method {
 		case http.MethodGet:
 			rows, err := db.Query(`SELECT id, body, created_at FROM messages ORDER BY created_at DESC LIMIT 50`)
@@ -256,12 +269,14 @@ func main() {
 
 	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		t := time.Now()
-		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
-		defer cancel()
-		if err := db.PingContext(ctx); err != nil {
-			http.Error(w, "not-ready: "+err.Error(), 503)
-			observe(r.Method, "/ready", 503, t)
-			return
+		if dbEnabled {
+			ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+			defer cancel()
+			if err := db.PingContext(ctx); err != nil {
+				http.Error(w, "not-ready: "+err.Error(), 503)
+				observe(r.Method, "/ready", 503, t)
+				return
+			}
 		}
 		_, _ = w.Write([]byte("ready"))
 		observe(r.Method, "/ready", 200, t)

--- a/templates/web-nodejs/src/index.js
+++ b/templates/web-nodejs/src/index.js
@@ -307,25 +307,31 @@ async function connectWithRetry(maxAttempts, delayMs) {
   }
 }
 
+// Postgres is OPTIONAL. If <DB_PREFIX>_HOST is unset (no postgres binding),
+// the Message Wall API is disabled and the home page shows a friendly
+// 'no DB bound' placeholder. /metrics, /health, /ready still work.
+const dbEnabled = !!process.env[`${dbPrefix}_HOST`];
+
 async function start() {
-  if (!process.env[`${dbPrefix}_HOST`]) {
-    console.error(`💀 No ${dbPrefix}_HOST in env — bind a postgresql service via deploy/values.yaml services[]`);
-    process.exit(1);
+  if (!dbEnabled) {
+    console.log(`ℹ️  No ${dbPrefix}_HOST in env — postgres binding not configured; serving placeholder.`);
+    console.log(`   To enable Message Wall: rda add-service postgresql ${dbPrefix.toLowerCase()}, flip enabled:true, fill auth slots.`);
+  } else {
+    await connectWithRetry(60, 2000);   // up to 60 attempts × 2s = 2min budget
+    console.log('✅ Connected to PostgreSQL at ' + env('HOST') + ':' + env('PORT', '5432'));
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS messages (
+        id         SERIAL PRIMARY KEY,
+        body       TEXT NOT NULL CHECK (char_length(body) <= 280),
+        created_at TIMESTAMPTZ DEFAULT NOW()
+      )
+    `);
+    console.log('✅ Table ready');
+
+    const { rows: [{ count }] } = await client.query('SELECT COUNT(*) FROM messages');
+    messagesCurrent.set(parseInt(count));
   }
-  await connectWithRetry(60, 2000);   // up to 60 attempts × 2s = 2min budget
-  console.log('✅ Connected to PostgreSQL at ' + env('HOST') + ':' + env('PORT', '5432'));
-
-  await client.query(`
-    CREATE TABLE IF NOT EXISTS messages (
-      id         SERIAL PRIMARY KEY,
-      body       TEXT NOT NULL CHECK (char_length(body) <= 280),
-      created_at TIMESTAMPTZ DEFAULT NOW()
-    )
-  `);
-  console.log('✅ Table ready');
-
-  const { rows: [{ count }] } = await client.query('SELECT COUNT(*) FROM messages');
-  messagesCurrent.set(parseInt(count));
 
   const server = http.createServer(async (req, res) => {
     const end = httpDuration.startTimer();
@@ -342,6 +348,18 @@ async function start() {
         res.writeHead(200, { 'Content-Type': promClient.register.contentType });
         res.end(metrics);
         return; // don't pollute the histogram with /metrics noise
+      }
+      if (req.url === '/api/messages') {
+        if (!dbEnabled) {
+          status = 503;
+          res.writeHead(503, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            error: 'messages api unavailable: no postgres binding configured',
+            hint: 'rda add-service postgresql ' + dbPrefix.toLowerCase() + ', flip enabled:true, fill auth slots',
+          }));
+          end({ method: req.method, path: '/api/messages', status: 503 });
+          return;
+        }
       }
       if (req.method === 'GET' && req.url === '/api/messages') {
         const { rows } = await client.query(
@@ -391,6 +409,12 @@ async function start() {
         return;
       }
       if (req.url === '/ready') {
+        if (!dbEnabled) {
+          // No DB to probe; report ready as long as the process is up.
+          res.writeHead(200); res.end('ready');
+          end({ method: req.method, path: '/ready', status: 200 });
+          return;
+        }
         try {
           await client.query('SELECT 1');
           res.writeHead(200); res.end('ready');


### PR DESCRIPTION
When the dev runs `rda new <project> --template web-go` (or web-nodejs) and `tilt up` WITHOUT `rda add-service postgresql`, the app pod crash-looped at startup:

```
💀 No DB_HOST in env — bind a postgresql service via deploy/values.yaml services[]
```

Real-world surfaced when a dev added ONLY `rda add-service dex auth` (no postgres) and tried `tilt up`.

## Fix

Postgres is now OPTIONAL in both templates.
- DB binding present (`<DB_PREFIX>_HOST` set): connect, init schema, serve Message Wall (full demo).
- DB binding absent: log a friendly 'no DB binding configured' line, skip DB setup. `/metrics`, `/health`, `/ready` work; `/api/messages` returns 503 with remediation hint; home page renders the placeholder.

## Verified

- Go build: `go build -tags heroku ./...` rc=0
- Node syntax: `node --check` rc=0
- Existing scenario 15 (postgres+dex) still passes (this change is additive)
- New scenario 16 (rda-e2e-tests, separate PR) covers the vanilla+dex case and asserts pod Ready, no DB_HOST in env, /health and /ready return 200.

## Why this slipped past before

Scenario 15 always sets `services[].enabled: true` for postgres. The template's fatal-exit was reached only in flows we hadn't tested.