### PR TITLE
feat(auth): project AUTH_PUBLIC_URL + AUTH_ISSUER auto-derived from ingress

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.26
+version: 0.11.27
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -438,27 +438,56 @@ charts:
         # cross-binding concern (a postgres binding feeding dex), out of
         # scope for the dex catalog entry's auth-seed declaration.
         binding_secret:
+          # Identity / type info — present on all bindings; skip_env
+          # keeps these out of the projected env-var list (we only
+          # want the connectivity bits as <BINDING>_* env vars).
           - {key: type, literal: dex, skip_env: true}
           - {key: provider, literal: dexidp-upstream, skip_env: true}
+
+          # ─── Connectivity (in-cluster) ─────────────────────────
+          # Stable in-cluster Service URL. Always set, regardless of
+          # whether ingress is enabled. Apps' Kubernetes-side OIDC
+          # libraries (token verifiers, JWKS fetch) hit this. App pod
+          # env: <BINDING>_HOST, <BINDING>_PORT, <BINDING>_URL.
           - {key: host, template: "{{ .Release.Name }}-dex"}
           - {key: port, literal: "5556"}
-          # url is the OIDC issuer URL — the same value the dev
-          # configured at config.issuer, surfaced to consuming apps as
-          # DEX_URL. App OIDC libraries expect this shape.
           - {key: url, template: "http://{{ .Release.Name }}-dex:5556"}
-          # Issuer must match dex.config.issuer — that's auto-derived
-          # via derived_values above. Here we mirror the same logic
-          # so AUTH_ISSUER (the env var the app pod reads) matches the
-          # browser-facing URL the user actually hits.
-          # Today `template:` only has access to .Release.Name, not
-          # the service entry — so we hardcode the in-cluster fallback.
-          # Devs whose ingress is enabled should rely on AUTH_PUBLIC_URL
-          # (TODO #90) for the browser-facing URL; AUTH_ISSUER stays
-          # in-cluster for token verification (which is fine — both
-          # token "iss" and verifier hit the same in-cluster endpoint
-          # when the app's OIDC client uses AUTH_PUBLIC_URL for the
-          # discovery, then validates against AUTH_ISSUER's JWKS).
-          - {key: issuer, template: "http://{{ .Release.Name }}-dex:5556"}
+
+          # ─── OIDC issuer (auto-derives from ingress.host) ──────
+          # This MUST equal whatever URL the *browser* hits. When
+          # ingress is enabled, that's the ingress URL; when not,
+          # it's the in-cluster Service URL (which the browser then
+          # only reaches through tilt port-forward or in-cluster
+          # workloads that aren't human-driven).
+          #
+          # `derived_values:` above writes .Values.dex.config.issuer
+          # on render. We just read it back here. App pod env:
+          # <BINDING>_ISSUER. Token verifiers compare token's
+          # `iss` claim against this — auto-derivation eliminates the
+          # mismatch class of bugs.
+          - key: issuer
+            template: |
+              {{- if and .Values.dex .Values.dex.config .Values.dex.config.issuer -}}
+              {{ .Values.dex.config.issuer }}
+              {{- else -}}
+              http://{{ .Release.Name }}-dex:5556
+              {{- end -}}
+
+          # ─── Public URL (browser-facing) ───────────────────────
+          # Same value as `issuer` today (auto-derived from ingress).
+          # Kept as a separate key so apps can branch their UX:
+          #   - <BINDING>_PUBLIC_URL — where to redirect the browser
+          #   - <BINDING>_ISSUER     — what the verifier expects in iss
+          # If a future config splits them (e.g. dex behind a TLS-
+          # terminating proxy with a /dex path mount, or external SSO
+          # passthrough), the binding contract stays stable.
+          - key: public_url
+            template: |
+              {{- if and .Values.dex .Values.dex.config .Values.dex.config.issuer -}}
+              {{ .Values.dex.config.issuer }}
+              {{- else -}}
+              http://{{ .Release.Name }}-dex:5556
+              {{- end -}}
 
         scaffold:
           # DSL fields (mapped via values_mapping)

--- a/templates/web-nodejs/src/index.js
+++ b/templates/web-nodejs/src/index.js
@@ -27,13 +27,19 @@ const PORT = parseInt(process.env.PORT || '8080');
 const ACCENT_COLOR = "#736def";
 // ─────────────────────────────────────────────
 
-// ─── Dex SSO (optional) ──────────────────────
-// Set DEX_PUBLIC_URL to the external (Ingress) URL of your dex
-// instance, e.g. "http://dex.localtest.me/dex". OIDC client lookup
-// uses standard discovery at <issuer>/.well-known/openid-configuration.
-// The client_id must match a staticClient registered in dex's config.
-const DEX_PUBLIC_URL = process.env.DEX_PUBLIC_URL || '';
+// ─── OIDC SSO (optional) ─────────────────────
+// Reads <AUTH_BINDING>_PUBLIC_URL from the binding-secret. Default binding
+// name is "auth"; override via AUTH_BINDING=<name> to read from a different
+// binding (e.g. binding=idp → IDP_PUBLIC_URL). Auto-derived from the dex
+// chart's ingress.host (or in-cluster URL if no ingress) — no manual edit
+// needed in deploy/values.yaml.
+const authPrefix = (process.env.AUTH_BINDING || 'AUTH').toUpperCase();
+const AUTH_PUBLIC_URL = process.env[`${authPrefix}_PUBLIC_URL`] || '';
 const OIDC_CLIENT_ID = process.env.OIDC_CLIENT_ID || 'message-wall';
+// Back-compat alias: older code (and anyone who copy-pasted the
+// pre-0.11.27 template) still references DEX_PUBLIC_URL. Keep it
+// working when AUTH_PUBLIC_URL is set.
+const DEX_PUBLIC_URL = AUTH_PUBLIC_URL;
 // ─────────────────────────────────────────────
 
 // ─── Prometheus metrics ──────────────────────
@@ -445,7 +451,7 @@ async function start() {
   server.listen(PORT, () => {
     console.log('🚀 Server running on http://localhost:' + PORT);
     console.log('📊 Metrics at http://localhost:' + PORT + '/metrics');
-    if (DEX_PUBLIC_URL) console.log('🔐 OIDC: ' + DEX_PUBLIC_URL);
+    if (AUTH_PUBLIC_URL) console.log('🔐 OIDC: ' + AUTH_PUBLIC_URL);
   });
 }
 


### PR DESCRIPTION
Stage 1 of the auth UX overhaul (idefxH/rda-cli#90). Drops the manual fiddling with OIDC URLs and the class of bugs where issuer/ingress drift apart.

## What apps see now

```
<BINDING>_HOST       in-cluster Service host
<BINDING>_PORT       5556
<BINDING>_URL        http://<release>-dex:5556 (in-cluster)
<BINDING>_ISSUER     http://<ingress.host> when ingress enabled, else in-cluster
<BINDING>_PUBLIC_URL http://<ingress.host> when ingress enabled, else in-cluster
```

`<BINDING>` = the user's binding name uppercase. Apps read these via the binding-secret env-var projection.

## Use case

```js
// web-nodejs (auto-rewired in this PR):
const authPrefix = (process.env.AUTH_BINDING || 'AUTH').toUpperCase();
const AUTH_PUBLIC_URL = process.env[`${authPrefix}_PUBLIC_URL`] || '';
// → http://idp.test.localtest.me when ingress.host is set
// → http://test-dex:5556 otherwise (in-cluster only)
```

The browser hits AUTH_PUBLIC_URL for the OIDC dance. The token's `iss` claim auto-matches because dex.config.issuer derives from the same source.

## Why this slipped past before

dex's binding-secret hardcoded `issuer` to the in-cluster URL. Tokens from a browser-facing dex (ingress) claimed the ingress URL, but apps verified against the in-cluster URL → 401. Real bug we hit.

## Verified

```
TEST 1 (ingress enabled, host=idp.pub.localtest.me):
  issuer:     http://idp.pub.localtest.me  ✓
  public_url: http://idp.pub.localtest.me  ✓

TEST 2 (ingress disabled):
  issuer:     http://testrelease-dex:5556  ✓
  public_url: http://testrelease-dex:5556  ✓
```

binding-secret-multiport-render test guard still passes (13 keys per dex Secret).

## Stages remaining (separate PRs)

- web-go: go-oidc + protected /admin route demo
- rda-docs/concepts/auth.md: end-to-end guide
- e2e scenario: assert AUTH_PUBLIC_URL is in the projected env