### PR TITLE
feat(web-go,web-nodejs): browser-cookie OIDC flow (/login /callback /admin /logout)

### DIFF
--- a/templates/web-go/main.go
+++ b/templates/web-go/main.go
@@ -8,13 +8,17 @@
 //      browser-side login via oidc-client-ts (CDN). AUTH_BINDING
 //      defaults to 'AUTH'; override (e.g. AUTH_BINDING=idp) to read
 //      from a different binding's PUBLIC_URL projection.
-//   4. /admin endpoint — Bearer-token-validated server-side route.
-//      When AUTH_ISSUER + OIDC_CLIENT_ID are set, /admin verifies an
-//      id_token (Authorization: Bearer <jwt>) against the issuer's
-//      JWKS endpoint via in-cluster URL (so localtest.me ingress URLs
-//      stay browser-only — see InsecureIssuerURLContext rationale in
-//      the verifier init below). Returns claims JSON on success, 401
-//      on failure.  Browser-cookie session flow is a follow-on PR.
+//   4. OIDC server-side flow — Browser-cookie session + Bearer API.
+//      When AUTH_URL + AUTH_ISSUER + OIDC_CLIENT_ID are set, the app
+//      gates /admin behind a verified id_token. Two ways to provide
+//      the token:
+//        a. session cookie (id_token), set by /auth/callback after
+//           the OAuth2 code grant flow (/login → dex authorize →
+//           callback → cookie → /admin).
+//        b. Authorization: Bearer <jwt> header, for server-to-server
+//           or curl. The Bearer path doesn't need OIDC_CLIENT_SECRET.
+//      The browser flow needs OIDC_CLIENT_SECRET (the staticClient's
+//      secret field in dex's passthrough.config.staticClients).
 //
 // The Postgres binding is read from env vars projected by the rda
 // library helper (services[].binding=db => DB_HOST, DB_PORT,
@@ -25,13 +29,16 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -68,8 +75,20 @@ var (
 	authURL      = os.Getenv(authPrefix + "_URL")
 	// Back-compat alias for projects that haven't migrated to AUTH_BINDING.
 	dexPublicURL = authPublicURL
-	oidcClientID = envOrDefault("OIDC_CLIENT_ID", "message-wall")
-	startTime    = time.Now()
+	oidcClientID     = envOrDefault("OIDC_CLIENT_ID", "message-wall")
+	// oidcClientSecret is required for the /login → /auth/callback browser
+	// flow (OAuth2 code grant). The Bearer path doesn't need it. Set it
+	// via suse-library.env in deploy/values.yaml (or, better, projected
+	// from a Secret). Empty → /login returns 503 with a remediation hint.
+	oidcClientSecret = os.Getenv("OIDC_CLIENT_SECRET")
+	// sessionCookieName is what /auth/callback sets and /admin reads.
+	// Override via SESSION_COOKIE_NAME if you have multiple apps on the
+	// same parent domain (cookies are scoped by domain, not path).
+	sessionCookieName = envOrDefault("SESSION_COOKIE_NAME", "id_token")
+	// stateCookieName is the short-lived random anti-CSRF cookie set by
+	// /login and verified by /auth/callback.
+	stateCookieName = "oidc_state"
+	startTime       = time.Now()
 
 	// OIDC verifier — populated in main() if OIDC is configured.
 	// nil otherwise; /admin returns 503 in that case.
@@ -311,21 +330,151 @@ func main() {
 		}
 	})
 
-	// /admin — protected route. Validates an Authorization: Bearer
-	// <jwt> against the OIDC verifier (configured at startup from
-	// AUTH_URL + AUTH_ISSUER + OIDC_CLIENT_ID). Returns the token's
-	// claims as JSON on success.
+	// ─── OIDC: /login → /auth/callback → /admin (browser flow) ─────
+	//                /admin (Bearer flow for API/curl)
+	//                /logout
 	//
-	// To get a token from the dex IdP:
-	//   curl -X POST <AUTH_URL>/token \\
-	//     -d grant_type=password -d username=<staticPasswords email> \\
-	//     -d password=... -d client_id=<staticClient id> \\
-	//     -d client_secret=... -d "scope=openid profile email"
-	// Then:
-	//   curl -H "Authorization: Bearer <id_token>" http://<app>/admin
-	//
-	// Browser-cookie session flow (/login → /auth/callback → cookie)
-	// is the next step — currently this route is API-only.
+	// Two-mode protected route. The browser path uses an OAuth2
+	// authorization-code flow with a session cookie holding the
+	// id_token. The API path takes Authorization: Bearer <jwt>. Both
+	// validate the id_token via the same oidcVerifier — issuer,
+	// signature, audience, expiry. Bearer doesn't need
+	// OIDC_CLIENT_SECRET; the browser flow does.
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		t := time.Now()
+		if oidcVerifier == nil {
+			httpJSONError(w, 503, fmt.Errorf("oidc not configured"))
+			observe(r.Method, "/login", 503, t)
+			return
+		}
+		if oidcClientSecret == "" {
+			httpJSONError(w, 503, fmt.Errorf("OIDC_CLIENT_SECRET unset — required for browser flow (the staticClient's secret in dex's passthrough.config.staticClients[].secret); set via suse-library.env in deploy/values.yaml or project from a Secret"))
+			observe(r.Method, "/login", 503, t)
+			return
+		}
+		state, err := randomHex(16)
+		if err != nil {
+			httpJSONError(w, 500, fmt.Errorf("state gen: %w", err))
+			observe(r.Method, "/login", 500, t)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name: stateCookieName, Value: state, Path: "/",
+			HttpOnly: true, SameSite: http.SameSiteLaxMode, MaxAge: 600,
+			Secure: cookieSecure(r),
+		})
+		redirectURI := appBaseURL(r) + "/auth/callback"
+		params := url.Values{
+			"response_type": {"code"},
+			"client_id":     {oidcClientID},
+			"redirect_uri":  {redirectURI},
+			"scope":         {"openid profile email"},
+			"state":         {state},
+		}
+		http.Redirect(w, r, authPublicURL+"/auth?"+params.Encode(), http.StatusFound)
+		observe(r.Method, "/login", http.StatusFound, t)
+	})
+
+	mux.HandleFunc("/auth/callback", func(w http.ResponseWriter, r *http.Request) {
+		t := time.Now()
+		if oidcVerifier == nil {
+			httpJSONError(w, 503, fmt.Errorf("oidc not configured"))
+			observe(r.Method, "/auth/callback", 503, t)
+			return
+		}
+		stateCookie, err := r.Cookie(stateCookieName)
+		if err != nil || stateCookie.Value == "" {
+			httpJSONError(w, 400, fmt.Errorf("missing %s cookie — start at /login", stateCookieName))
+			observe(r.Method, "/auth/callback", 400, t)
+			return
+		}
+		if r.URL.Query().Get("state") != stateCookie.Value {
+			httpJSONError(w, 400, fmt.Errorf("state mismatch — possible CSRF"))
+			observe(r.Method, "/auth/callback", 400, t)
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			httpJSONError(w, 400, fmt.Errorf("missing code query param"))
+			observe(r.Method, "/auth/callback", 400, t)
+			return
+		}
+		// Exchange code for tokens via the IN-CLUSTER URL (authURL),
+		// not authPublicURL — the pod can't necessarily reach the
+		// browser-facing ingress. dex accepts both; the redirect_uri
+		// param must match exactly what /login sent (browser-facing).
+		form := url.Values{
+			"grant_type":    {"authorization_code"},
+			"code":          {code},
+			"redirect_uri":  {appBaseURL(r) + "/auth/callback"},
+			"client_id":     {oidcClientID},
+			"client_secret": {oidcClientSecret},
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+		defer cancel()
+		req, _ := http.NewRequestWithContext(ctx, "POST", authURL+"/token",
+			strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			httpJSONError(w, 502, fmt.Errorf("token exchange POST %s/token failed: %w", authURL, err))
+			observe(r.Method, "/auth/callback", 502, t)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			body, _ := io.ReadAll(resp.Body)
+			httpJSONError(w, 502, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, body))
+			observe(r.Method, "/auth/callback", 502, t)
+			return
+		}
+		var tokenResp struct {
+			AccessToken string `json:"access_token"`
+			IDToken     string `json:"id_token"`
+			TokenType   string `json:"token_type"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+			httpJSONError(w, 502, fmt.Errorf("decode token response: %w", err))
+			observe(r.Method, "/auth/callback", 502, t)
+			return
+		}
+		if tokenResp.IDToken == "" {
+			httpJSONError(w, 502, fmt.Errorf("no id_token in token response"))
+			observe(r.Method, "/auth/callback", 502, t)
+			return
+		}
+		// Validate the id_token before trusting it (defence in depth —
+		// dex already signed it, but we want to fail loud on issuer /
+		// audience mismatches that would later trip /admin too).
+		if _, err := oidcVerifier.Verify(ctx, tokenResp.IDToken); err != nil {
+			httpJSONError(w, 502, fmt.Errorf("received id_token failed verification: %w", err))
+			observe(r.Method, "/auth/callback", 502, t)
+			return
+		}
+		// Set the session cookie + clear the state cookie. id_token JWTs
+		// from dex with default config are ~1h; cookie matches.
+		http.SetCookie(w, &http.Cookie{
+			Name: stateCookieName, Value: "", Path: "/", MaxAge: -1,
+		})
+		http.SetCookie(w, &http.Cookie{
+			Name: sessionCookieName, Value: tokenResp.IDToken, Path: "/",
+			HttpOnly: true, SameSite: http.SameSiteLaxMode, MaxAge: 3600,
+			Secure: cookieSecure(r),
+		})
+		http.Redirect(w, r, "/", http.StatusFound)
+		observe(r.Method, "/auth/callback", http.StatusFound, t)
+	})
+
+	mux.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
+		t := time.Now()
+		http.SetCookie(w, &http.Cookie{
+			Name: sessionCookieName, Value: "", Path: "/", MaxAge: -1,
+		})
+		http.Redirect(w, r, "/", http.StatusFound)
+		observe(r.Method, "/logout", http.StatusFound, t)
+	})
+
+	// /admin — Bearer header OR session cookie. Both verified the same way.
 	mux.HandleFunc("/admin", func(w http.ResponseWriter, r *http.Request) {
 		t := time.Now()
 		if oidcVerifier == nil {
@@ -338,25 +487,26 @@ func main() {
 			observe(r.Method, "/admin", 503, t)
 			return
 		}
-		authHdr := r.Header.Get("Authorization")
-		if !strings.HasPrefix(authHdr, "Bearer ") {
+		rawIDToken, source := extractIDToken(r)
+		if rawIDToken == "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("WWW-Authenticate", "Bearer realm=\""+authIssuer+"\"")
 			w.WriteHeader(401)
 			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error": "missing or malformed Authorization: Bearer <jwt> header",
+				"error":  "unauthenticated — no Bearer header AND no session cookie",
+				"hint":   "GET /login to start the browser flow, OR send Authorization: Bearer <jwt>",
 				"issuer": authIssuer,
 			})
 			observe(r.Method, "/admin", 401, t)
 			return
 		}
-		rawIDToken := strings.TrimPrefix(authHdr, "Bearer ")
 		idToken, err := oidcVerifier.Verify(r.Context(), rawIDToken)
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(401)
 			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error": "id_token verification failed: " + err.Error(),
+				"error":  "id_token verification failed: " + err.Error(),
+				"source": source,
 			})
 			observe(r.Method, "/admin", 401, t)
 			return
@@ -370,6 +520,7 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"authenticated": true,
+			"source":        source,
 			"subject":       idToken.Subject,
 			"issuer":        idToken.Issuer,
 			"audience":      idToken.Audience,
@@ -649,3 +800,51 @@ const htmlPage = `<!DOCTYPE html>
   {{end}}
 </body>
 </html>`
+
+// extractIDToken returns the JWT and which source it came from
+// ("cookie" or "bearer"). Cookie wins when both are present (browser
+// session is the canonical path; Bearer is for curl/API).
+func extractIDToken(r *http.Request) (string, string) {
+	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
+		return c.Value, "cookie"
+	}
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer "), "bearer"
+	}
+	return "", ""
+}
+
+// randomHex generates n random bytes hex-encoded — used for the state
+// cookie's anti-CSRF nonce. crypto/rand for non-predictability.
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// appBaseURL returns the scheme://host the user's browser sees,
+// honouring X-Forwarded-Proto (set by the Ingress controller) so we
+// build the redirect_uri correctly when behind TLS termination.
+func appBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
+		scheme = fwd
+	}
+	return scheme + "://" + r.Host
+}
+
+// cookieSecure flags the cookie Secure when serving over https. Lax-only
+// in HTTP dev (Tilt's default) so the cookie is still set.
+func cookieSecure(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return r.Header.Get("X-Forwarded-Proto") == "https"
+}
+

--- a/templates/web-nodejs/package-lock.json
+++ b/templates/web-nodejs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "jose": "^5.9.0",
         "pg": "^8.13.1",
         "prom-client": "^15.1.3"
       },
@@ -30,6 +31,15 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/pg": {
       "version": "8.20.0",

--- a/templates/web-nodejs/package.json
+++ b/templates/web-nodejs/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "pg": "^8.13.1",
-    "prom-client": "^15.1.3"
+    "prom-client": "^15.1.3",
+    "jose": "^5.9.0"
   },
   "engines": {
     "node": "22"

--- a/templates/web-nodejs/src/index.js
+++ b/templates/web-nodejs/src/index.js
@@ -19,6 +19,12 @@
 const http = require('http');
 const { Client } = require('pg');
 const promClient = require('prom-client');
+const crypto = require('crypto');
+const { URL, URLSearchParams } = require('url');
+// jose: pure-JS, lightweight JWKS fetcher + JWT verifier. Imported
+// dynamically inside the OIDC bootstrap to keep startup fast when
+// auth is disabled (the dep tree is ~50 modules).
+let jose = null;
 
 const PORT = parseInt(process.env.PORT || '8080');
 
@@ -35,7 +41,26 @@ const ACCENT_COLOR = "#736def";
 // needed in deploy/values.yaml.
 const authPrefix = (process.env.AUTH_BINDING || 'AUTH').toUpperCase();
 const AUTH_PUBLIC_URL = process.env[`${authPrefix}_PUBLIC_URL`] || '';
+// AUTH_URL is the in-cluster URL (auth-binding-secret host:port). Used
+// for JWKS fetch + token-exchange POST since localtest.me ingresses
+// don't resolve from inside the pod. AUTH_PUBLIC_URL is what the
+// browser hits.
+const AUTH_URL = process.env[`${authPrefix}_URL`] || '';
+// AUTH_ISSUER is what tokens claim in their `iss` field — must match
+// the chart's dex.config.issuer. Auto-derived alongside AUTH_PUBLIC_URL
+// (bundle 0.11.27+).
+const AUTH_ISSUER = process.env[`${authPrefix}_ISSUER`] || AUTH_PUBLIC_URL;
 const OIDC_CLIENT_ID = process.env.OIDC_CLIENT_ID || 'message-wall';
+// OIDC_CLIENT_SECRET is required for the /login → /auth/callback browser
+// flow (OAuth2 code grant). The Bearer path doesn't need it. Set via
+// suse-library.env or project from a Secret. Empty → /login returns 503.
+const OIDC_CLIENT_SECRET = process.env.OIDC_CLIENT_SECRET || '';
+const SESSION_COOKIE_NAME = process.env.SESSION_COOKIE_NAME || 'id_token';
+const STATE_COOKIE_NAME = 'oidc_state';
+// Holds the JWKS fetcher once jose is loaded + AUTH_URL is set. Keep
+// outside any one request handler so the keyset cache (HTTP TTL handled
+// by jose) is shared across requests.
+let jwksFetcher = null;
 // Back-compat alias: older code (and anyone who copy-pasted the
 // pre-0.11.27 template) still references DEX_PUBLIC_URL. Keep it
 // working when AUTH_PUBLIC_URL is set.
@@ -298,6 +323,81 @@ const startTime = Date.now();
 // failure instead of exiting — so the readiness probe never gets a
 // healthy response and the pod gets killed anyway. Retrying gives
 // postgres time to finish init while we keep the process alive.
+// ─── OIDC server-side helpers (browser cookie flow + Bearer) ────
+
+function appBaseURL(req) {
+  // Honour X-Forwarded-Proto from the Ingress controller. Falls back
+  // to http (Tilt's local dev).
+  const proto = req.headers['x-forwarded-proto'] || 'http';
+  return `${proto}://${req.headers.host}`;
+}
+
+function parseCookies(cookieHeader) {
+  if (!cookieHeader) return {};
+  const out = {};
+  for (const c of cookieHeader.split(';')) {
+    const [k, ...rest] = c.trim().split('=');
+    if (k) out[k] = rest.join('=');
+  }
+  return out;
+}
+
+function setCookie(res, name, value, opts = {}) {
+  const parts = [`${name}=${value}`, 'Path=/', 'HttpOnly', 'SameSite=Lax'];
+  if (opts.maxAge !== undefined) parts.push(`Max-Age=${opts.maxAge}`);
+  if (opts.secure) parts.push('Secure');
+  // Append to any existing Set-Cookie (Node lets you pass an array).
+  const prev = res.getHeader('Set-Cookie');
+  const cookie = parts.join('; ');
+  res.setHeader('Set-Cookie', prev ? [].concat(prev, cookie) : cookie);
+}
+
+function clearCookie(res, name) {
+  setCookie(res, name, '', { maxAge: 0 });
+}
+
+// Initialise the JWKS keyset on first use. Lazy because jose's import
+// + JWKS fetch are non-trivial; only pay the cost when /admin or
+// /auth/callback fires for the first time.
+async function getJWKS() {
+  if (!AUTH_URL || !AUTH_ISSUER || !OIDC_CLIENT_ID) return null;
+  if (jwksFetcher) return jwksFetcher;
+  if (!jose) jose = await import('jose');
+  // JWKS URI uses the in-cluster URL (pod-reachable) even though the
+  // OIDC discovery's jwks_uri claims the browser-facing one — same
+  // keys served at <issuer>/keys whichever URL gets us there.
+  jwksFetcher = jose.createRemoteJWKSet(new URL(`${AUTH_URL}/keys`));
+  return jwksFetcher;
+}
+
+// Validate a JWT against the configured issuer + audience.  Returns
+// the decoded payload on success; throws on any failure (signature,
+// expiry, issuer mismatch, audience mismatch).
+async function verifyIDToken(rawJWT) {
+  const jwks = await getJWKS();
+  if (!jwks) throw new Error('OIDC not configured');
+  if (!jose) jose = await import('jose');
+  const { payload } = await jose.jwtVerify(rawJWT, jwks, {
+    issuer: AUTH_ISSUER,
+    audience: OIDC_CLIENT_ID,
+  });
+  return payload;
+}
+
+// Extract the id_token from cookie OR Authorization: Bearer header.
+// Returns { token, source } or { token: '' } if neither is present.
+function extractIDToken(req) {
+  const cookies = parseCookies(req.headers.cookie);
+  if (cookies[SESSION_COOKIE_NAME]) {
+    return { token: cookies[SESSION_COOKIE_NAME], source: 'cookie' };
+  }
+  const auth = req.headers.authorization || '';
+  if (auth.startsWith('Bearer ')) {
+    return { token: auth.slice('Bearer '.length), source: 'bearer' };
+  }
+  return { token: '', source: '' };
+}
+
 async function connectWithRetry(maxAttempts, delayMs) {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
@@ -355,6 +455,152 @@ async function start() {
         res.end(metrics);
         return; // don't pollute the histogram with /metrics noise
       }
+
+      // ── OIDC: /login → /auth/callback → /admin (browser cookie)
+      //         /admin (Bearer too — same verify, no cookie needed)
+      //         /logout
+      if (req.url === '/login' || req.url.startsWith('/login?')) {
+        if (!AUTH_URL || !AUTH_ISSUER || !OIDC_CLIENT_ID) {
+          res.writeHead(503, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'oidc not configured', hint: 'set AUTH_BINDING + bind dex via rda add-service dex auth' }));
+          end({ method: req.method, path: '/login', status: 503 });
+          return;
+        }
+        if (!OIDC_CLIENT_SECRET) {
+          res.writeHead(503, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            error: 'OIDC_CLIENT_SECRET unset',
+            hint: 'required for browser flow (the staticClient secret in dex passthrough); set via suse-library.env or project from a Secret',
+          }));
+          end({ method: req.method, path: '/login', status: 503 });
+          return;
+        }
+        const state = crypto.randomBytes(16).toString('hex');
+        setCookie(res, STATE_COOKIE_NAME, state, { maxAge: 600 });
+        const redirectURI = appBaseURL(req) + '/auth/callback';
+        const params = new URLSearchParams({
+          response_type: 'code',
+          client_id: OIDC_CLIENT_ID,
+          redirect_uri: redirectURI,
+          scope: 'openid profile email',
+          state: state,
+        });
+        res.writeHead(302, { Location: AUTH_PUBLIC_URL + '/auth?' + params.toString() });
+        res.end();
+        end({ method: req.method, path: '/login', status: 302 });
+        return;
+      }
+
+      if (req.url.startsWith('/auth/callback')) {
+        const u = new URL(req.url, appBaseURL(req));
+        const cookies = parseCookies(req.headers.cookie);
+        const expectedState = cookies[STATE_COOKIE_NAME];
+        if (!expectedState) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: `missing ${STATE_COOKIE_NAME} cookie — start at /login` }));
+          end({ method: req.method, path: '/auth/callback', status: 400 });
+          return;
+        }
+        if (u.searchParams.get('state') !== expectedState) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'state mismatch — possible CSRF' }));
+          end({ method: req.method, path: '/auth/callback', status: 400 });
+          return;
+        }
+        const code = u.searchParams.get('code');
+        if (!code) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'missing code query param' }));
+          end({ method: req.method, path: '/auth/callback', status: 400 });
+          return;
+        }
+        try {
+          // Exchange code → tokens via the IN-CLUSTER URL (AUTH_URL).
+          const tokenResp = await fetch(AUTH_URL + '/token', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+              grant_type: 'authorization_code',
+              code: code,
+              redirect_uri: appBaseURL(req) + '/auth/callback',
+              client_id: OIDC_CLIENT_ID,
+              client_secret: OIDC_CLIENT_SECRET,
+            }),
+          });
+          if (!tokenResp.ok) {
+            const body = await tokenResp.text();
+            throw new Error(`token endpoint returned ${tokenResp.status}: ${body}`);
+          }
+          const tokens = await tokenResp.json();
+          if (!tokens.id_token) throw new Error('no id_token in token response');
+          // Defence in depth — verify before trusting.
+          await verifyIDToken(tokens.id_token);
+          // Cookie matches the dex default 1h token life.
+          clearCookie(res, STATE_COOKIE_NAME);
+          setCookie(res, SESSION_COOKIE_NAME, tokens.id_token, { maxAge: 3600 });
+          res.writeHead(302, { Location: '/' });
+          res.end();
+          end({ method: req.method, path: '/auth/callback', status: 302 });
+          return;
+        } catch (err) {
+          res.writeHead(502, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: err.message }));
+          end({ method: req.method, path: '/auth/callback', status: 502 });
+          return;
+        }
+      }
+
+      if (req.url === '/logout') {
+        clearCookie(res, SESSION_COOKIE_NAME);
+        res.writeHead(302, { Location: '/' });
+        res.end();
+        end({ method: req.method, path: '/logout', status: 302 });
+        return;
+      }
+
+      if (req.url === '/admin') {
+        if (!AUTH_URL || !AUTH_ISSUER || !OIDC_CLIENT_ID) {
+          res.writeHead(503, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'oidc not configured' }));
+          end({ method: req.method, path: '/admin', status: 503 });
+          return;
+        }
+        const { token, source } = extractIDToken(req);
+        if (!token) {
+          res.writeHead(401, {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': `Bearer realm="${AUTH_ISSUER}"`,
+          });
+          res.end(JSON.stringify({
+            error: 'unauthenticated — no Bearer header AND no session cookie',
+            hint: 'GET /login to start the browser flow, OR send Authorization: Bearer <jwt>',
+            issuer: AUTH_ISSUER,
+          }));
+          end({ method: req.method, path: '/admin', status: 401 });
+          return;
+        }
+        try {
+          const claims = await verifyIDToken(token);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            authenticated: true,
+            source,
+            subject: claims.sub,
+            issuer: claims.iss,
+            audience: claims.aud,
+            expires_at: claims.exp,
+            claims,
+          }, null, 2));
+          end({ method: req.method, path: '/admin', status: 200 });
+          return;
+        } catch (err) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'id_token verification failed: ' + err.message, source }));
+          end({ method: req.method, path: '/admin', status: 401 });
+          return;
+        }
+      }
+
       if (req.url === '/api/messages') {
         if (!dbEnabled) {
           status = 503;


### PR DESCRIPTION
Stage 2 of #95. Server-side OAuth2 code-grant flow + session cookie for BOTH templates. The Bearer-token API path on web-go (PR #111) is preserved as a fallback.

Both templates expose the same shape:

```
GET /login         → 302 dex authorize (sets state cookie)
GET /auth/callback → exchanges code → token (via in-cluster AUTH_URL),
                     verifies id_token, sets session cookie
GET /logout        → clears cookie
GET /admin         → cookie OR Bearer; verify; return claims JSON
```

## Required env

- AUTH_URL, AUTH_ISSUER, OIDC_CLIENT_ID — auto-projected from the dex binding (PR #109)
- OIDC_CLIENT_SECRET — must match the staticClient.secret in dex passthrough; user sets via `suse-library.env` or projects from a Secret

## Verified

go build, node --check, 5 bundle test guards all pass.