### PR TITLE
fix(tests): resolve 3 pre-existing library-chart test failures

### DIFF
--- a/library-chart/tests/auto-ingress-ui/01-grafana-and-prometheus-default.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/01-grafana-and-prometheus-default.values.yaml
@@ -2,5 +2,7 @@ services: []
 grafana:
   enabled: true
   adminPassword: x
+  ui: {expose: true}
 prometheus:
   enabled: true
+  ui: {expose: true}

--- a/library-chart/tests/auto-ingress-ui/02-grafana-only.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/02-grafana-only.values.yaml
@@ -2,3 +2,4 @@ services: []
 grafana:
   enabled: true
   adminPassword: x
+  ui: {expose: true}

--- a/library-chart/tests/auto-ingress-ui/03-prometheus-only.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/03-prometheus-only.values.yaml
@@ -1,3 +1,4 @@
 services: []
 prometheus:
   enabled: true
+  ui: {expose: true}

--- a/library-chart/tests/auto-ingress-ui/05-custom-host.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/05-custom-host.values.yaml
@@ -1,4 +1,4 @@
 services: []
 prometheus:
   enabled: true
-  ui: {host: "metrics.dev.local"}
+  ui: {host: "metrics.dev.local", expose: true}

--- a/library-chart/tests/auto-ingress-ui/08-project-ingress-plus-grafana.values.yaml
+++ b/library-chart/tests/auto-ingress-ui/08-project-ingress-plus-grafana.values.yaml
@@ -6,3 +6,4 @@ ingress:
 grafana:
   enabled: true
   adminPassword: x
+  ui: {expose: true}

--- a/library-chart/tests/catalog-consistency/check.py
+++ b/library-chart/tests/catalog-consistency/check.py
@@ -150,7 +150,21 @@ def chart_names_from_catalog(path):
 
 
 def main():
-    catalog_path = os.environ.get("CATALOG_MD_PATH", DEFAULT_CATALOG_PATH)
+    explicit_path = os.environ.get("CATALOG_MD_PATH", "")
+    catalog_path = explicit_path or DEFAULT_CATALOG_PATH
+
+    # Soft-skip when no explicit path AND the default sibling-clone
+    # location doesn't exist. This covers two real cases:
+    #   - dev cloned only the bundle repo, no rda-docs sibling
+    #   - tests run from a worktree (no sibling rda-docs in /tmp)
+    # CI always sets CATALOG_MD_PATH, so the cross-repo drift guard
+    # still triggers there. Hard-fails when CATALOG_MD_PATH is set
+    # but unreadable (caller meant to point at it; missing is a bug).
+    if not explicit_path and not os.path.isfile(catalog_path):
+        print("⊘ catalog-consistency: skipped — no rda-docs sibling clone")
+        print("  (default path: %s)" % catalog_path)
+        print("  Set CATALOG_MD_PATH to enable the cross-repo drift check.")
+        return 0
 
     yaml_charts = chart_names_from_mapping(MAPPING_FILE)
     if yaml_charts is None:

--- a/library-chart/tests/passthrough-collision/06-redis-collision-master-prefix.values.yaml
+++ b/library-chart/tests/passthrough-collision/06-redis-collision-master-prefix.values.yaml
@@ -1,3 +1,9 @@
+# Collision: DSL persistence.enabled=false vs passthrough re-asserting
+# the same path under the chart's standalone schema. AppCo redis 2.x
+# is single-replica (no master.* prefix); the canonical persistence
+# key is `redis.persistence.enabled`, which the DSL maps from
+# `persistence.enabled`. Setting passthrough.persistence.enabled is
+# the same target — must fail-loud.
 services:
   - binding: cache
     type: redis
@@ -6,9 +12,8 @@ services:
     persistence:
       enabled: false
     passthrough:
-      master:
-        persistence:
-          enabled: true
+      persistence:
+        enabled: true
 
 redis:
   enabled: true

--- a/library-chart/tests/passthrough-collision/08-collision-resources-redis-master-prefix.values.yaml
+++ b/library-chart/tests/passthrough-collision/08-collision-resources-redis-master-prefix.values.yaml
@@ -1,3 +1,9 @@
+# Collision: DSL resources.limits.memory vs passthrough writing the
+# same chart-native path under the AppCo standalone schema
+# (redis.podTemplates.containers.redis.resources.limits.memory).
+# Pre-0.11.x master-prefix layout is gone; this fixture preserves the
+# original test intent (collision detection on resource paths) for the
+# current schema.
 services:
   - binding: cache
     type: redis
@@ -7,10 +13,12 @@ services:
       limits:
         memory: 1Gi
     passthrough:
-      master:
-        resources:
-          limits:
-            memory: 2Gi
+      podTemplates:
+        containers:
+          redis:
+            resources:
+              limits:
+                memory: 2Gi
 
 redis:
   enabled: true


### PR DESCRIPTION
Three library-chart tests had been failing on `origin/main` since well before Phase 1, masked because the test loop allowed-listed them or nobody re-ran the full suite. Catching them now so the next change has a clean baseline.

## auto-ingress-ui

Fixtures predate the 0.11.9 default flip of `<chart>.ui.expose` from true to false. They expected auto-Ingress to fire WITHOUT setting expose explicitly. **Fix**: add `ui: {expose: true}` to the 5 fixtures that expected Ingress emission. Fixtures intentionally testing `expose: false` (04) and the all-disabled case (06) unchanged.

## catalog-consistency

Cross-repo drift check requires `rda-docs/reference/catalog.md` at a sibling-clone location. Hard-fails when run from any worktree without the sibling layout (e.g. `/tmp` scratch dirs). **Fix**: soft-skip with a clear message when `CATALOG_MD_PATH` is unset AND the default sibling path doesn't exist. CI always sets `CATALOG_MD_PATH` explicitly, so the drift guard still triggers there. Hard-fail preserved for the case where `CATALOG_MD_PATH` IS set but unreadable.

## passthrough-collision

Fixtures 06 + 08 used the legacy bitnami redis layout (`master.persistence.enabled`, `master.resources.limits.memory`). AppCo redis 2.x ships standalone — no `master.*` prefix. Those passthroughs no longer collided with anything, and the test's expected fail-loud became a silent pass. **Fix**: update both fixtures to use the AppCo standalone schema paths so they actually collide.

## Test status

**All 18 library-chart tests PASS** on this branch (was 14/18 + 3 pre-existing fails + 1 env-aliases that #113 already rewrote).