### PR TITLE
feat(library 0.11.29): dex binding_fields {issuer, public_url}

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.28
+version: 0.11.29
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -2,7 +2,7 @@
 
 ## META
 Deployment:   helm-library-chart
-Version: 0.11.28
+Version: 0.11.29
 Spec-Schema:  0.1.0
 Author:       François-Xavier Houard <fx.houard@gmail.com>
 License:      Apache-2.0
@@ -661,3 +661,36 @@ Status: in-progress
 
 - Spec META.Version 0.11.22 → 0.11.28 (skips 0.11.23–0.11.27 used
   for in-flight features without dedicated SPEC milestones).
+
+## MILESTONE: 0.11.29
+- dex dsl-mappings entry gains `binding_fields:` block exposing
+  `issuer` and `public_url` as `${binding:NAME.<field>}` references
+  resolvable at render time. Same template as the existing
+  `derived_values: dex.config.issuer` (the chart's internal
+  configuration). Activates rda-cli #112 (MILESTONE 0.1.55) at
+  runtime: workloads can now write
+  `AUTH_ISSUER: ${binding:auth.issuer}` in their
+  `suse-library.env:` block and the value resolves to the same
+  URL dex's discovery endpoint serves.
+
+- `public_url` is intentionally the same value as `issuer` (dex's
+  contract is "issuer URL == public URL"). Exposed separately for
+  app-side symmetry with the `AUTH_PUBLIC_URL` convention used by
+  the web-go / web-nodejs OIDC templates — those apps read
+  AUTH_PUBLIC_URL for browser-facing redirect URIs and
+  AUTH_ISSUER for token-signature verification, even though both
+  resolve to the same string in dex's case.
+
+- No code changes; pure dsl-mappings.yaml extension. The
+  rda-cli renderer (already merged in #112) walks
+  `binding_fields:` and stores the rendered values in
+  BindingFields.Computed, accessible via Get(<field>).
+
+- TESTS: covered by the existing
+  `tests/dsl-mappings-schema/` validator (yaml well-formed) and
+  `tests/dsl-mappings-target-validity/` (target paths point at
+  real chart values). No new test guard required — the binding_fields
+  surface is exercised by the rda-cli unit tests in
+  `internal/render/bindingref_computed_test.go`.
+
+- Spec META.Version 0.11.28 → 0.11.29.

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -415,6 +415,32 @@ charts:
               {{- else -}}
               http://{{ .Release.Name }}-dex:5556
               {{- end -}}
+        # Cross-binding refs (rda-cli 0.1.55+, MILESTONE 0.11.29).
+        # Surfaces dex's computed URLs as `${binding:NAME.<field>}`
+        # references workloads can use in their `suse-library.env:`
+        # block. Same template as derived_values above (the chart's
+        # internal config.issuer); exposing the same value as a
+        # binding field lets `AUTH_ISSUER: ${binding:auth.issuer}`
+        # resolve to the URL the chart's discovery endpoint actually
+        # returns. `public_url` is the same value (dex's issuer ==
+        # public URL by design); both are exposed for app-side
+        # symmetry with the AUTH_PUBLIC_URL convention used by the
+        # web-go / web-nodejs templates' OIDC code.
+        binding_fields:
+          issuer:
+            template: |
+              {{- if .Service.ingress.enabled -}}
+              http://{{ index .Service.ingress "host" }}
+              {{- else -}}
+              http://{{ .Release.Name }}-dex:5556
+              {{- end -}}
+          public_url:
+            template: |
+              {{- if .Service.ingress.enabled -}}
+              http://{{ index .Service.ingress "host" }}
+              {{- else -}}
+              http://{{ .Release.Name }}-dex:5556
+              {{- end -}}
         # Chart-required fields the DSL doesn't surface (because they
         # don't vary across deployments). `rda render` writes these
         # AFTER applying values_mapping, only when at least one

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -40,7 +40,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.28
+  version: 0.11.29
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled


### PR DESCRIPTION
Activates [rda-cli #112](https://github.com/idefxH/rda-cli/pull/112) / MILESTONE 0.1.55 at runtime by adding the dex `binding_fields:` entries.

## What

Workloads can now write `AUTH_ISSUER: ${binding:auth.issuer}` in their `suse-library.env:` block and the value resolves to the URL dex's discovery endpoint serves. Same template as the existing `derived_values: dex.config.issuer` (the chart's internal configuration), exposed as a binding field.

`public_url` is intentionally the same value as `issuer` (dex's contract is "issuer URL == public URL"). Exposed separately for app-side symmetry with the AUTH_PUBLIC_URL convention used by the web-go / web-nodejs OIDC templates.

## No code changes

Pure `dsl-mappings.yaml` extension. The rda-cli renderer (merged in #112) walks `binding_fields:` and stores the rendered values in `BindingFields.Computed`, accessible via `Get`.

## PCD

- **Spec** (`library-chart/SPEC.md`): MILESTONE 0.11.29 + META.Version bump.
- **Code**: `library-chart/dsl-mappings.yaml` adds `binding_fields:{issuer, public_url}` to dex; `library-chart/Chart.yaml` 0.11.28→0.11.29; `rda-bundle.yaml` library_chart.version 0.11.28→0.11.29.
- **Tests**: 18/18 library-chart tests pass (zero regressions). Behaviour itself is unit-tested in rda-cli's `bindingref_computed_test.go`.

## Phase 1 of DO 0001-A — feature-complete + e2e-validated

| Component | PR | Status |
|---|---|---|
| rda-cli env_resolved producer | rda-cli #108 | merged |
| rda-cli BEHAVIOR/render spec | rda-cli #109 | merged |
| rda-cli doctor --bootstrap | rda-cli #110 | merged (independent) |
| rda-cli add-service env scaffold | rda-cli #111 | merged |
| rda-cli chart-author binding_fields | rda-cli #112 | merged |
| rda-cli inline `# →` comments | rda-cli #113 | merged |
| bundle deployment.yaml iteration | bundle #113 | merged |
| bundle 3 pre-existing test fails | bundle #114 | merged |
| bundle dex binding_fields runtime | **THIS PR** | open |
| rda-docs operator.md doctor --bootstrap | rda-docs #30 | merged |
| e2e scenario 18 | e2e-tests #14 | open |