### PR TITLE
fix(templates): authPrefix converts dashes to underscores when reading <BINDING>_* env (closes #116) (0.11.30)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.29
+version: 0.11.30
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -694,3 +694,31 @@ Status: in-progress
   `internal/render/bindingref_computed_test.go`.
 
 - Spec META.Version 0.11.28 → 0.11.29.
+
+## MILESTONE: 0.11.30
+
+- BUGFIX: web-go + web-nodejs templates' `authPrefix` now converts dashes
+  to underscores before reading the binding-prefixed env vars
+  (`<AUTH_PREFIX>_PUBLIC_URL`, etc.). Closes idefxH/rda-opinion-bundle-example#116.
+
+- Why it matters: when `AUTH_BINDING=auth-prod` (any binding name with a
+  dash), `strings.ToUpper("auth-prod")` produced `AUTH-PROD` and the app
+  read `os.Getenv("AUTH-PROD_PUBLIC_URL")` — but the binding-secret
+  helper projects env vars with dashes converted to underscores
+  (`AUTH_PROD_*`). Result: a dashed binding silently disabled OIDC,
+  with `/admin` → 503 even though dex + binding-secret were correctly
+  wired.
+
+- Fix is a one-line normalisation in both templates:
+
+      // web-go
+      authPrefix = strings.ReplaceAll(strings.ToUpper(envOrDefault("AUTH_BINDING", "AUTH")), "-", "_")
+
+      // web-nodejs
+      const authPrefix = (process.env.AUTH_BINDING || 'AUTH').toUpperCase().replace(/-/g, '_');
+
+- Surfaced live during e2e scenario 21
+  (idefxH/rda-e2e-tests#15) on both templates with random binding
+  names like `auth-7f295296`.
+
+- Spec library-chart version 0.11.29 → 0.11.30.

--- a/templates/web-go/main.go
+++ b/templates/web-go/main.go
@@ -57,7 +57,13 @@ const accentColor = "#736def"
 
 var (
 	dbPrefix     = strings.ToUpper(envOrDefault("DB_BINDING", "DB"))
-	authPrefix   = strings.ToUpper(envOrDefault("AUTH_BINDING", "AUTH"))
+	// AUTH_BINDING may contain dashes (e.g. "auth-prod"). The bundle's
+	// binding-secret helper projects env vars with dashes converted to
+	// underscores (AUTH_PROD_*), so we apply the same normalisation
+	// when computing the lookup prefix. Without this, a dashed binding
+	// name silently disables OIDC (the env vars exist but under names
+	// the app never reads).
+	authPrefix   = strings.ReplaceAll(strings.ToUpper(envOrDefault("AUTH_BINDING", "AUTH")), "-", "_")
 	// authPublicURL is the browser-facing OIDC issuer URL — auto-derived
 	// from services[].ingress.host by rda render + the binding-secret's
 	// public_url key (bundle 0.11.27+). Empty when no auth binding is

--- a/templates/web-nodejs/src/index.js
+++ b/templates/web-nodejs/src/index.js
@@ -39,7 +39,13 @@ const ACCENT_COLOR = "#736def";
 // binding (e.g. binding=idp → IDP_PUBLIC_URL). Auto-derived from the dex
 // chart's ingress.host (or in-cluster URL if no ingress) — no manual edit
 // needed in deploy/values.yaml.
-const authPrefix = (process.env.AUTH_BINDING || 'AUTH').toUpperCase();
+// AUTH_BINDING may contain dashes (e.g. 'auth-prod'). The bundle's
+// binding-secret helper projects env vars with dashes converted to
+// underscores (AUTH_PROD_*), so we apply the same normalisation when
+// computing the lookup prefix. Without this, a dashed binding name
+// silently disables OIDC (the env vars exist but under names the app
+// never reads).
+const authPrefix = (process.env.AUTH_BINDING || 'AUTH').toUpperCase().replace(/-/g, '_');
 const AUTH_PUBLIC_URL = process.env[`${authPrefix}_PUBLIC_URL`] || '';
 // AUTH_URL is the in-cluster URL (auth-binding-secret host:port). Used
 // for JWKS fetch + token-exchange POST since localtest.me ingresses


### PR DESCRIPTION
Closes #116. One-line bugfix in both templates' OIDC env reader.

## Bug

When `AUTH_BINDING` contains a dash (any binding name like `auth-prod` / `auth-staging` / `auth-7f295296`), the template's `strings.ToUpper("auth-prod")` produced `AUTH-PROD` and the app read `os.Getenv("AUTH-PROD_PUBLIC_URL")` — which returns `""` because the bundle's binding-secret helper projects env vars with **dashes converted to underscores** (`AUTH_PROD_PUBLIC_URL`).

Result: a dashed binding silently disabled OIDC, with `/admin` returning `503` even though dex + binding-secret were correctly wired. The pod logs even said the right thing — `OIDC verifier disabled — set <AUTH-PROD>_URL, <AUTH-PROD>_ISSUER, OIDC_CLIENT_ID` — but those env names with dashes don't exist.

## Fix

Both templates normalise the prefix the same way the binding-secret helper does:

**web-go** (`templates/web-go/main.go`):
```go
authPrefix = strings.ReplaceAll(strings.ToUpper(envOrDefault("AUTH_BINDING", "AUTH")), "-", "_")
```

**web-nodejs** (`templates/web-nodejs/src/index.js`):
```js
const authPrefix = (process.env.AUTH_BINDING || 'AUTH').toUpperCase().replace(/-/g, '_');
```

## Surfaced from

- idefxH/rda-e2e-tests#15 (scenario 21 — fullstack auth flow with random per-run binding names like `auth-7f295296`).

## Verification

- `go build ./...` parses (template can't actually build standalone — `module {{ .Name }}` placeholder in `go.mod`).
- `node --check templates/web-nodejs/src/index.js` passes.
- E2E scenario 21 reproduced the bug pre-fix; post-fix the auth path resolves cleanly.

## Spec

`library-chart/Chart.yaml` `0.11.29 → 0.11.30`. `library-chart/SPEC.md` MILESTONE 0.11.30.
