### PR TITLE
feat(dsl-mappings): dex auth.users + auth.clients capabilities (Phase 2.4 of DO 0001) (0.11.31)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.30
+version: 0.11.31
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -722,3 +722,76 @@ Status: in-progress
   names like `auth-7f295296`.
 
 - Spec library-chart version 0.11.29 → 0.11.30.
+
+## MILESTONE: 0.11.31
+
+- FEATURE: dex chart declares its first capabilities (Phase 2.4 of
+  Design Orientation 0001) — `auth.users` and `auth.clients`. Both
+  use the `file-static` backend (Phase 2.2): user-supplied items
+  under `services[].bootstrap.<cap>:` materialise into the chart's
+  values overlay at the same chart-author-side keys the chart
+  already uses (`dex.config.staticPasswords`, `dex.config.staticClients`).
+
+- `auth.users` schema:
+
+      schema:
+        name:     { type: string, required: true }
+        password: { type: string, required: true, secret: true }
+      projection:
+        target:    dex.config.staticPasswords
+        transform: bcrypt-password-to-hash
+        field_map: { name: email }
+
+  The bcrypt transform (Phase 2.2) replaces `password:` with `hash:`
+  using cost-10 `$2a$` so dex consumes the rendered list verbatim.
+  The `field_map` renames `name` → `email` because that's what
+  `staticPasswords` entries use chart-side; users get to write the
+  more natural `name:` key.
+
+- `auth.clients` schema:
+
+      schema:
+        id:           { type: string, required: true }
+        secret:       { type: string, required: true, secret: true }
+        redirectURIs: { type: list,   required: true }
+        name:         { type: string }                # optional consent label
+      projection:
+        target: dex.config.staticClients
+
+  No `field_map` (dex's natural shape matches), no transform (secrets
+  stored verbatim in dev mode; ExternalSecrets/Vault is the production
+  path documented in `concepts/auth.md`).
+
+- Two API surfaces for the same data (transition window): users can
+  still write `services[].passthrough.config.staticClients:` /
+  `staticPasswords:` verbatim. Capabilities project AFTER passthrough
+  at render time, so `bootstrap.auth.{users,clients}` wins when both
+  are set. The passthrough escape-hatch stays as the universal
+  ad-hoc-fields path for keys that don't yet have a typed capability
+  declared (custom connectors, kubernetes-storage tuning, etc).
+
+- Why dex first: it was the pilot in DO 0001 §3.4 because the chart
+  has TWO capabilities (auth.users + auth.clients), each with a
+  different transform/field-map need (bcrypt + identity), exercising
+  the full Phase 2.2 backend surface in one chart.
+
+- TESTS: validated end-to-end on M2 Studio with bundle 0.11.31 +
+  rda-cli 0.1.65 (the projection-target-suseOut fix). A test project
+  with `bootstrap.auth.users: [...]` + `bootstrap.auth.clients: [...]`
+  renders to a `values.generated.yaml` whose `dex.config.staticPasswords`
+  contains bcrypted entries and whose `dex.config.staticClients`
+  contains verbatim id/secret/redirectURIs. Existing schema validator
+  (`tests/dsl-mappings-schema/`) accepts the new `capabilities:` block
+  (it doesn't enforce known top-level keys at the version-entry level
+  — a forward-compatibility design).
+
+- DEFERRED: `postgresql.db.schemas` (initially listed in the DO 0001
+  pilot triple) does NOT land in this milestone. AppCo postgresql 0.4.x
+  doesn't expose user-init-SQL through values (its `scripts:` ConfigMap
+  globs only internal lifecycle scripts; there is no `primary.initdb.scripts`
+  knob). The clean V1 path for postgres bootstrap SQL is `api-job` (a
+  post-install Job running `psql`) — that's Phase 2 V2 / api-job
+  backend, not file-initdb. Tracked as a separate issue against the
+  bundle.
+
+- Spec library-chart version 0.11.30 → 0.11.31.

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -553,6 +553,62 @@ charts:
           passthrough.config.staticPasswords:
             default: []
 
+        # ─── Capabilities (Phase 2 of DO 0001-A) ───────────────────
+        # Bootstrap-data the dex chart accepts: a typed list of users
+        # the IdP should know about, and a typed list of OIDC clients
+        # apps register with. Devs declare these under
+        # `services[].bootstrap.auth.users:` / `bootstrap.auth.clients:`
+        # in their values.yaml — the renderer materialises them at
+        # `dex.config.staticPasswords` / `dex.config.staticClients`,
+        # the same shape this chart's scaffold pre-fills as `[]`.
+        #
+        # Once a chart declares a capability, the user has two API
+        # surfaces for the same data:
+        #   1. `services[].passthrough.config.staticPasswords:` (verbatim)
+        #   2. `services[].bootstrap.auth.users:`           (typed)
+        # Capabilities project AFTER passthrough at render time, so
+        # `bootstrap.auth.users` wins when both are set. The
+        # passthrough path stays for ad-hoc fields that don't yet have
+        # a capability declared (kubernetes-storage tuning, custom
+        # connector blocks, etc).
+        #
+        # The CLI (`rda bootstrap auth.users add ...` / `rda bootstrap
+        # auth.clients add ...`) edits this same `bootstrap.<cap>` list
+        # in values.yaml, with field-validation against the schema below.
+        capabilities:
+          auth.users:
+            backend: file-static
+            order: 1
+            schema:
+              name:     { type: string, required: true }
+              password: { type: string, required: true, secret: true }
+            projection:
+              target:    dex.config.staticPasswords
+              transform: bcrypt-password-to-hash
+              # User writes `name:`; dex's staticPasswords expects `email:`.
+              # The bcrypt transform replaces `password:` with `hash:` (the
+              # field dex actually consumes, with $2a$ cost-10 bcrypt).
+              field_map:
+                name: email
+          auth.clients:
+            backend: file-static
+            order: 2
+            schema:
+              id:           { type: string,        required: true }
+              secret:       { type: string,        required: true, secret: true }
+              redirectURIs: { type: list,          required: true }
+              # `name` is the optional human-readable label dex shows
+              # on the consent screen. Apps that never display the
+              # consent screen (skipApprovalScreen=true, the bundle
+              # default) can omit it.
+              name:         { type: string }
+            projection:
+              target: dex.config.staticClients
+              # No field_map — dex's staticClients schema is identical
+              # to ours: id / secret / redirectURIs / name.
+              # No transform — secrets are stored verbatim (dev-mode);
+              # ExternalSecrets / Vault is the production path.
+
   mariadb:
     versions:
       - constraint: ">=0.1.0 <1.0.0"

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -40,7 +40,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.29
+  version: 0.11.31
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled


### PR DESCRIPTION
Phase 2.4 of Design Orientation 0001: the dex chart declares its first two capabilities so the moteur (schema 2.1 / renderer 2.2 / CLI 2.3) reaches a real user.

## What lands

library-chart/dsl-mappings.yaml charts.dex.versions[0] gains a capabilities: block declaring auth.users and auth.clients — both file-static backend, materialising to dex.config.staticPasswords and dex.config.staticClients respectively.

- auth.users uses the bcrypt-password-to-hash transform and name->email field_map.
- auth.clients is identity-mapped (no transform, no field_map).

## User-visible result

Two transitional API surfaces for the same data:

- (legacy) services[].passthrough.config.staticClients/staticPasswords - verbatim YAML, dev had to know dex chart-side schema and bcrypt manually.
- (typed) services[].bootstrap.auth.users / .auth.clients - schema-validated, bcrypted at render time, no chart-side leak.

Capabilities project AFTER passthrough so bootstrap.* wins. Pairs with: rda bootstrap auth.users add alice@example.com --field password=...

## Companion PR

rda-cli #124 is REQUIRED. It fixes the renderer wiring (capabilities target nesting bug, where projectCapabilities was called with chartBlock instead of suseOut, making outputs silently invisible) AND rda bootstrap Resolve() to look at deploy/values.yaml. Without it, this bundle PR is inert.

## Deferred

postgresql.db.schemas (originally listed in DO 0001 V1 pilot) does NOT land here. AppCo postgresql 0.4.x has no user-facing init-SQL knob (its scripts: ConfigMap globs only internal lifecycle scripts). The clean V1 path is api-job (post-install Job running psql) - Phase 2 V2, separate issue.

## Validation

End-to-end on M2 Studio: a test project with bootstrap.auth.users + bootstrap.auth.clients renders to a values.generated.yaml whose dex.config.staticPasswords contains bcrypt-hashed entries and whose dex.config.staticClients contains verbatim id/secret/redirectURIs. Schema validator accepts the new capabilities: block.

Refs: bundle 0.11.30->0.11.31, rda-bundle.yaml 0.11.29->0.11.31, library-chart/SPEC.md MILESTONE 0.11.31, rda-cli #124.