### PR TITLE
feat(dex): OIDC dev-ready scaffold in 2 commands (0.11.32)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.31
+version: 0.11.32
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -795,3 +795,65 @@ Status: in-progress
   bundle.
 
 - Spec library-chart version 0.11.30 → 0.11.31.
+
+## MILESTONE: 0.11.32
+
+- FEATURE: dex scaffold is now OIDC-dev-ready in 2 commands (`rda new
+  <p>` + `rda add-service dex auth`) without ANY manual values.yaml
+  edit. Three additions to the dex catalogue entry:
+
+  1. `passthrough.config.oauth2.passwordConnector: local` is added
+     to the scaffold defaults. dex's `/token` endpoint refuses
+     `grant_type=password` with `unsupported_grant_type` unless this
+     is set to a connector supporting password auth — `local` is the
+     built-in passwordDB connector. Required for `curl -X POST
+     /token`-style password-grant flows (the canonical e2e check).
+     Browser-cookie OIDC flows work without it; we set it because the
+     cost is zero.
+
+  2. `bootstrap.auth.users` and `bootstrap.auth.clients` are
+     pre-filled in the scaffold defaults:
+
+         bootstrap:
+           auth.users:
+             - name: dev@example.com
+               password: dev
+           auth.clients:
+             - id: "{{.ProjectName}}-client"
+               secret: dev-secret
+               name:   "{{.ProjectName}}"
+               redirectURIs:
+                 - "http://{{.ProjectName}}.localtest.me/auth/callback"
+                 - "http://localhost:18081/auth/callback"
+
+     Templating uses the existing `{{.ProjectName}}` placeholder
+     (already supported by `renderScaffoldTemplate` in rda-cli; no
+     code change needed). The second redirectURI handles the
+     `kubectl port-forward 18081:80` flow used in dev / e2e.
+
+  3. `binding_secret` gains three new keys so the app pod env reads
+     `<BINDING>_CLIENT_ID`, `<BINDING>_CLIENT_SECRET`, and
+     `<BINDING>_REDIRECT_URI` automatically (no hand-written
+     `value:` literals). Each is templated against
+     `.Values.dex.config.staticClients[0].*` so the source of truth
+     stays the dev-editable `bootstrap.auth.clients[0]` (or whatever
+     the first staticClients entry resolves to post-render).
+
+     Result: `rda add-service dex auth` now scaffolds 8 env entries
+     under `suse-library.env` instead of 5
+     (`AUTH_HOST/PORT/URL/ISSUER/PUBLIC_URL` + the 3 new
+     `CLIENT_ID/CLIENT_SECRET/REDIRECT_URI`).
+
+- User-visible result: `rda new myapp --template web-go && cd myapp
+  && rda add-service dex auth && tilt up` (after flipping
+  `enabled: true` on the binding) gives a working OIDC chain. No
+  manual yaml editing, no `htpasswd`, no `--field redirectURIs=...`
+  CLI gymnastics.
+
+- The pre-filled `dev@example.com / dev` is a DEV credential —
+  staging+ devs replace the bootstrap.auth.users entries (`rda
+  bootstrap auth.users rm dev@example.com` then `add` real users)
+  and swap the connector to github / oidc / ldap per the
+  production flow documented in `concepts/auth.md`.
+
+- Spec library-chart version 0.11.31 → 0.11.32.

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -515,6 +515,42 @@ charts:
               http://{{ .Release.Name }}-dex:5556
               {{- end -}}
 
+          # ─── OIDC client trio (browser-side credentials) ───────
+          # Read from the FIRST entry of dex.config.staticClients
+          # post-render. The bundle scaffold pre-fills one client
+          # (id=<project>-client, secret=dev-secret, redirectURIs=
+          # http://<project>.localtest.me/auth/callback) so a fresh
+          # `rda new + rda add-service dex auth + tilt up` boots a
+          # working OIDC chain without manual edits. App pod env:
+          # <BINDING>_CLIENT_ID / _CLIENT_SECRET / _REDIRECT_URI.
+          # When the dev wants multiple clients (e.g. SPA + admin
+          # CLI), they edit `bootstrap.auth.clients[]` and the
+          # binding-secret keys still point at staticClients[0] —
+          # the canonical client.
+          - key: client_id
+            template: |
+              {{- if and .Values.dex .Values.dex.config .Values.dex.config.staticClients -}}
+              {{- with index .Values.dex.config.staticClients 0 -}}
+              {{ .id }}
+              {{- end -}}
+              {{- end -}}
+          - key: client_secret
+            template: |
+              {{- if and .Values.dex .Values.dex.config .Values.dex.config.staticClients -}}
+              {{- with index .Values.dex.config.staticClients 0 -}}
+              {{ .secret }}
+              {{- end -}}
+              {{- end -}}
+          - key: redirect_uri
+            template: |
+              {{- if and .Values.dex .Values.dex.config .Values.dex.config.staticClients -}}
+              {{- with index .Values.dex.config.staticClients 0 -}}
+              {{- if .redirectURIs -}}
+              {{ index .redirectURIs 0 }}
+              {{- end -}}
+              {{- end -}}
+              {{- end -}}
+
         scaffold:
           # DSL fields (mapped via values_mapping)
           # NOTE: `issuer` is no longer scaffolded — it's auto-derived from
@@ -552,6 +588,39 @@ charts:
             default: []
           passthrough.config.staticPasswords:
             default: []
+          # ─── OIDC password-grant connector ─────────────────────
+          # dex's /token endpoint refuses grant_type=password with
+          # `unsupported_grant_type` unless `oauth2.passwordConnector`
+          # names a connector that supports it (`local` for the
+          # built-in passwordDB). Required for any test/script that
+          # password-grants programmatically. Browser-cookie OIDC
+          # flows work without this; we set it because the cost is
+          # zero and password-grant-via-curl is the simplest e2e
+          # check.
+          passthrough.config.oauth2.passwordConnector:
+            default: local
+            comment: "connector for password-grant; flip to '' if you only want browser flow"
+          # ─── Bootstrap-data defaults (Phase 2.4 of DO 0001) ────
+          # Pre-fills one dev user + one OIDC client so a fresh
+          # `rda new <p> && cd <p> && rda add-service dex auth &&
+          # tilt up` produces a working OIDC chain WITHOUT any
+          # manual values.yaml edit. Devs edit / replace these
+          # before promoting to staging+ (production: connectors,
+          # ExternalSecrets, real users — see concepts/auth.md).
+          bootstrap:
+            comment: "dev bootstrap data — replace before staging+"
+            default:
+              auth.users:
+                - name: dev@example.com
+                  password: dev
+              auth.clients:
+                - id: "{{.ProjectName}}-client"
+                  secret: dev-secret
+                  name: "{{.ProjectName}}"
+                  redirectURIs:
+                    - "http://{{.ProjectName}}.localtest.me/auth/callback"
+                    # second URL for `kubectl port-forward 18081:80` flow
+                    - "http://localhost:18081/auth/callback"
 
         # ─── Capabilities (Phase 2 of DO 0001-A) ───────────────────
         # Bootstrap-data the dex chart accepts: a typed list of users

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -40,7 +40,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.31
+  version: 0.11.32
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled


### PR DESCRIPTION
Phase 2.4 follow-up: removes the manual values.yaml editing required to get OIDC working after `rda add-service dex auth`. Three additions to the dex catalogue entry in dsl-mappings.yaml.

## 1. `passthrough.config.oauth2.passwordConnector: local`

dex's `/token` endpoint refuses `grant_type=password` with `unsupported_grant_type` unless `oauth2.passwordConnector` names a connector that supports it (`local` for the built-in passwordDB). Required for curl-driven password-grant flows; browser-cookie OIDC flows work without it but the cost of setting it is zero.

## 2. `bootstrap.auth.users` + `bootstrap.auth.clients` defaults

scaffold pre-fills one dev user (`dev@example.com` / `dev`) and one OIDC client (`id={{.ProjectName}}-client`, `secret=dev-secret`, `redirectURIs=[<project>.localtest.me/auth/callback, localhost:18081/auth/callback]`, `name={{.ProjectName}}`).

The second redirectURI covers the `kubectl port-forward 18081:80` flow used in inner-loop dev and e2e scenarios. Templating uses the existing `{{.ProjectName}}` placeholder — no rda-cli change needed.

## 3. `binding_secret` gains `client_id`, `client_secret`, `redirect_uri`

Each templated against `.Values.dex.config.staticClients[0].*` so the source of truth stays the dev-editable `bootstrap.auth.clients[0]`. `buildEnvScaffold` reads `binding_secret` entries verbatim, so `rda add-service dex auth` now scaffolds **8 env entries** under `suse-library.env` instead of 5:

```
AUTH_HOST AUTH_PORT AUTH_URL AUTH_ISSUER AUTH_PUBLIC_URL
AUTH_CLIENT_ID AUTH_CLIENT_SECRET AUTH_REDIRECT_URI    ← new
```

## User-visible result

```
rda new myapp --template web-go
cd myapp
rda add-service dex auth
# flip `enabled: true` on the auth binding (will be auto in a follow-up)
tilt up
```

Gives a working OIDC chain. No manual yaml editing, no `htpasswd`, no `--field redirectURIs=...` CLI gymnastics.

## Validation

- `dsl-mappings-schema` validator: green (10 charts catalogued)
- `dsl-mappings-target-validity` validator: green (88 paths cleanly parsed)
- End-to-end on M2 Studio: a fresh `rda new + rda add-service dex auth` followed by `rda render` produces a `values.generated.yaml` whose `dex.config.staticClients[0]` and `dex.config.staticPasswords[0]` are pre-filled, with the password bcrypted by the renderer's transform.

## Spec changes

- library-chart 0.11.31 → 0.11.32
- rda-bundle.yaml manifest version 0.11.31 → 0.11.32
- New MILESTONE: 0.11.32 in library-chart/SPEC.md

## Migration

Existing projects with hand-written `passthrough.config.staticClients` or `staticPasswords` keep working. No breaking change.