### PR TITLE
fix(web-go): Procfile uses absolute path to bypass POSIX-builtin shadow (0.11.33)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.32
+version: 0.11.33
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -857,3 +857,53 @@ Status: in-progress
   production flow documented in `concepts/auth.md`.
 
 - Spec library-chart version 0.11.31 → 0.11.32.
+
+## MILESTONE: 0.11.33
+
+- BUGFIX: web-go Procfile now uses an ABSOLUTE PATH for the
+  binary instead of the bare module name. Fixes a class of silent
+  crashloops where a project whose name matches a POSIX builtin
+  (test, time, echo, which, true, false, ...) starts but exits 1
+  without any output — kubectl logs is empty, container events
+  show only `Back-off restarting failed container` with no clue.
+
+- Root cause: the cnb launcher's runtime PATH does NOT include
+  `/layers/heroku_go/go_target/bin/` (the dir where heroku/go puts
+  the compiled binary), contrary to the comment in the previous
+  Procfile template which claimed it did. So `web: {{ .Name }}`
+  resolved through $PATH lookup. For a project named `test`, this
+  hit `/usr/bin/test` (the POSIX `test [expr]` builtin) which
+  exits 1 silently when called with no args. The Procfile launcher
+  doesn't print "command not found" because the lookup succeeded
+  — just at the wrong binary.
+
+- Diagnostic signature you'd see if you hit this in the future:
+
+      kubectl -n <ns> get pod -l app.kubernetes.io/name=<project>
+      <project>-...   0/1   CrashLoopBackOff   N (Xs ago)   Ym
+
+      kubectl logs <pod> --previous
+      <empty output>
+
+      kubectl describe pod <pod> | grep "Last State" -A 4
+        Last State: Terminated
+          Reason: Error
+          Exit Code: 1
+          Started:  ...
+          Finished: ... (same second — instant exit)
+
+- Fix: the template's Procfile now writes:
+
+      web: /layers/heroku_go/go_target/bin/{{ .Name }}
+      dev: /layers/heroku_go/go_target/bin/{{ .Name }}
+
+  Absolute paths bypass $PATH lookup entirely. Same dir as before,
+  just made explicit. The Procfile comments document the runtime
+  PATH situation + the POSIX-shadowing footgun for the next person.
+
+- Backwards-compat: existing projects keep working with the bare
+  name when the project name doesn't clash with a POSIX builtin —
+  but they're brittle. Migration: copy the absolute-path lines
+  from the current template Procfile into the project's Procfile.
+
+- Spec library-chart version 0.11.32 → 0.11.33.

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -40,7 +40,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.32
+  version: 0.11.33
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled

--- a/templates/web-go/Procfile
+++ b/templates/web-go/Procfile
@@ -1,9 +1,19 @@
 # CNB Procfile — declares the launch processes buildpacks register.
 #
-# heroku/go puts the compiled binary at:
+# heroku/go compiles the binary to:
 #   /layers/heroku_go/go_target/bin/<last-segment-of-module-path>
-# That dir is on $PATH at runtime, so we can invoke the binary by its
-# bare name (which is the project name from `module example.com/X`).
+#
+# IMPORTANT: that directory is NOT on $PATH at runtime in the cnb
+# launcher image (runtime PATH is roughly
+# /cnb/process:/cnb/lifecycle:/usr/{local/,}sbin:/usr/{local/,}bin:/sbin:/bin).
+# We therefore invoke the binary by its ABSOLUTE PATH below — using
+# the bare name `{{ .Name }}` is dangerous because:
+#   1. /usr/bin shadows it → if the project name clashes with a POSIX
+#      builtin (test, time, echo, which, true, false, ...), the
+#      launcher silently runs the POSIX binary and exits 1 with NO
+#      logs (no "command not found", no panic — just silent crashloop).
+#   2. Even non-clashing names rely on bash $PATH lookup which is
+#      brittle when buildpack versions change the runtime PATH.
 #
 # - web: production launch.
 # - dev: same as web for now. The Tilt extension's live_update
@@ -15,5 +25,5 @@
 #   in go.mod's `tool` directive — it breaks heroku/go's `web`
 #   process auto-registration: 'tried to set web to default but it
 #   doesn't exist'.)
-web: {{ .Name }}
-dev: {{ .Name }}
+web: /layers/heroku_go/go_target/bin/{{ .Name }}
+dev: /layers/heroku_go/go_target/bin/{{ .Name }}


### PR DESCRIPTION
## Bug

Projects whose name matches a POSIX builtin (`test`, `time`, `echo`, `which`, `true`, `false`, ...) silently crashloop with **no log output** and no obvious error. Container events show only `Back-off restarting failed container`; `kubectl logs --previous` is empty; `describe` shows `Last State Terminated, Exit Code: 1, Started/Finished` in the same second.

Discovered live debugging a `rda new test --template web-go` that crashlooped without explanation despite postgres + dex being healthy and the binding-secret/env projection working correctly.

## Root cause

The cnb launcher's runtime PATH does NOT include `/layers/heroku_go/go_target/bin/` (the dir where heroku/go puts the compiled binary), contrary to the previous template Procfile's comment which claimed it did. Runtime PATH is:

```
/cnb/process:/cnb/lifecycle:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

So `web: {{ .Name }}` triggered a `$PATH` lookup. For project name `test`, `/usr/bin/test` (the POSIX `test [expr]` builtin) got exec'd with no args → returned exit 1 silently.

**Why no log**: `/usr/bin/test` is a real executable, not a 'command not found' miss. The launcher doesn't print anything because exec succeeded — the binary that ran just happens to do nothing useful and exits 1.

Confirmed by running the binary directly with the absolute path:

```bash
docker run --rm --entrypoint /layers/heroku_go/go_target/bin/test test:tilt-...
# → produces the expected OIDC + DB bootstrap log lines, listens on :8080
```

## Fix

`templates/web-go/Procfile`:

```diff
- web: {{ .Name }}
- dev: {{ .Name }}
+ web: /layers/heroku_go/go_target/bin/{{ .Name }}
+ dev: /layers/heroku_go/go_target/bin/{{ .Name }}
```

Absolute paths bypass `$PATH` lookup entirely. Same binary, same launcher, just explicit. The Procfile comments now document the runtime-PATH gotcha + the POSIX-builtin shadow footgun for the next person.

## web-nodejs not affected

`templates/web-nodejs/Procfile` uses `node src/index.js` (explicit binary call), so the same class of bug doesn't apply. Only the go template needed the fix.

## Migration

Existing projects keep working when the project name doesn't clash with a POSIX builtin (most names don't). Migration for affected projects: copy the new absolute-path lines from this template's Procfile into the project's Procfile, then `tilt up` rebuilds.

## Spec changes

- library-chart 0.11.32 → 0.11.33
- rda-bundle.yaml manifest version 0.11.32 → 0.11.33
- New MILESTONE: 0.11.33 in library-chart/SPEC.md