### PR TITLE
fix(library-chart/ingress): use port.number not port.name (0.11.36)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.35
+version: 0.11.36
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -1001,3 +1001,49 @@ Status: in-progress
   normally. Same behavior on web-nodejs.
 
 - Spec library-chart version 0.11.34 → 0.11.35.
+
+## MILESTONE: 0.11.36
+
+- BUGFIX: `library-chart/templates/ingress.yaml` now references the
+  Service backend port by NUMBER (`port.number: 80`) instead of by
+  NAME (`port.name: http`). Fixes a 503 Service Unavailable on
+  Traefik 2.x (k3s, Rancher Desktop default).
+
+- Symptom: a project with `suse-library.ingress.enabled: true` and
+  a healthy app pod returned `503 Service Unavailable` from
+  `http://<host>.localtest.me/` even though the Service had endpoints
+  and `kubectl port-forward svc/<name> 18081:80` worked. Traefik
+  logs showed:
+
+      ERR Cannot create service error="service not found"
+        ingress=test namespace=test
+        serviceName=test
+        servicePort=&ServiceBackendPort{Name:http,Number:0}
+
+  The misleading "service not found" message is what Traefik emits
+  when it can't resolve a port-name backend reference on an
+  otherwise-existing Service.
+
+- Root cause: Traefik 2.x on k3s has a known issue resolving
+  `port.name` Service-backend references in some configurations
+  (the IngressClass+EndpointSlice path). `port.number` is always
+  reliable.
+
+- Fix is a 4-line YAML change: `port.name: http` → `port.number: 80`.
+  The number matches the Service template's hardcoded `port: 80`
+  (also in library-chart). Future cleanup: parameterise both via
+  `.Values.service.port`.
+
+- The dex-idp upstream chart already uses `port.number: 5556`, which
+  is why `auth.<host>.localtest.me` worked while `<host>.localtest.me`
+  was 503 with the same Traefik installation — different Ingress
+  template paths, only the library-chart's app Ingress was affected.
+
+- The `ingress-ui.yaml` template (services with `ui.expose: true`)
+  was already using `port.number: {{ $cfg.port }}` and was unaffected.
+
+- Validated end-to-end on M2 Studio: post-fix, `curl -i http://test.localtest.me/`
+  returns `HTTP/1.1 302 Found Location: /login` (the OIDC gate from
+  0.11.35), matching the expected behavior.
+
+- Spec library-chart version 0.11.35 → 0.11.36.

--- a/library-chart/templates/ingress.yaml
+++ b/library-chart/templates/ingress.yaml
@@ -24,7 +24,14 @@ spec:
               service:
                 name: {{ include "suse-library.name" $ }}
                 port:
-                  name: http
+                  # Use port NUMBER, not name. Traefik 2.x on k3s
+                  # (Rancher Desktop's default) fails to resolve
+                  # port-name references on Service backends, returning
+                  # 503 Service Unavailable with the misleading
+                  # `service not found` log. The Service template
+                  # hardcodes `port: 80`, so we mirror that here.
+                  # Future: parameterise both via .Values.service.port.
+                  number: 80
     {{- end }}
   {{- with .Values.ingress.tls }}
   tls:

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -40,7 +40,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.35
+  version: 0.11.36
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled


### PR DESCRIPTION
## Bug

Traefik 2.x on k3s (Rancher Desktop default) returns `503 Service Unavailable` when an Ingress backend references a Service port by name. The error log is misleading:

```
ERR Cannot create service error="service not found"
  ingress=test namespace=test serviceName=test
  servicePort=&ServiceBackendPort{Name:http,Number:0}
```

`service not found` actually means `port-name unresolved` — the Service exists, has endpoints, `kubectl port-forward` works fine, but Traefik refuses to route HTTP traffic.

Discovered live debugging a `rda new test` that scaffolded cleanly, deployed cleanly, but returned 503 on every request to `http://test.localtest.me/`. In-cluster `curl http://test.test.svc.cluster.local/` returned 302 correctly; only the Traefik path was broken.

## Fix

`library-chart/templates/ingress.yaml`:

```diff
  service:
    name: {{ include "suse-library.name" $ }}
    port:
-     name: http
+     number: 80
```

The number matches the Service template's hardcoded `port: 80`. Future cleanup: parameterise both via `.Values.service.port`.

## Why dex was unaffected

The `dex-idp` upstream chart's Ingress already uses `port.number: 5556`, which is why `auth.<host>.localtest.me` worked while `<host>.localtest.me` returned 503 with the same Traefik installation. Only the library-chart's app Ingress was affected.

## `ingress-ui.yaml` unaffected

The `ingress-ui.yaml` template (services with `ui.expose: true`) was already using `port.number: {{ $cfg.port }}`. No change needed there.

## Validation

Post-fix on M2 Studio (Rancher Desktop, dockerd):

```
$ curl -i http://test.localtest.me/
HTTP/1.1 302 Found
Location: /login
```

Matches the expected behavior with the OIDC gate from 0.11.35.

## Spec changes

- library-chart 0.11.35 → 0.11.36
- rda-bundle.yaml manifest version 0.11.35 → 0.11.36
- New MILESTONE: 0.11.36 in library-chart/SPEC.md