### PR TITLE
fix(dex/scaffold): ingress.enabled defaults to true (0.11.37)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.36
+version: 0.11.37
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -1047,3 +1047,44 @@ Status: in-progress
   0.11.35), matching the expected behavior.
 
 - Spec library-chart version 0.11.35 → 0.11.36.
+
+## MILESTONE: 0.11.37
+
+- BUGFIX: dex `scaffold.ingress.enabled` now defaults to `true`
+  (was `false`). Without ingress on a dex binding, the
+  binding-secret's `public_url` falls back to the in-cluster URL
+  `http://<release>-dex:5556` — which the BROWSER cannot reach.
+  Browser-side OIDC flows redirect to that unreachable URL and
+  stall ("ERR_NAME_NOT_RESOLVED" or worse, just hang).
+
+- This was the last friction in the "OIDC dev-ready in 2 commands"
+  promise. Pre-fix sequence required:
+    1. `rda new myapp --template web-go`
+    2. `cd myapp && rda add-service dex auth`
+    3. flip `services[binding=auth].enabled: true`     ← user edit
+    4. flip `services[binding=auth].ingress.enabled: true`  ← user edit (FORGOTTEN)
+    5. `tilt up`
+
+  The 4th step was the silent killer — devs flip step 3 and forget
+  step 4 because the scaffold doesn't hint that ingress matters
+  for OIDC. Post-fix, only step 3 remains; step 4 is the new
+  default.
+
+- Why dex-specific (not all bindings): postgres/redis/mariadb/etc
+  are pod-internal — apps reach them via `<BINDING>_HOST`
+  (in-cluster Service URL), no browser involved. Their default
+  `ingress.enabled: false` is correct. Dex is the only bundled
+  service whose flow REQUIRES the browser to reach it — hence
+  the special-case default.
+
+- Devs who want server-to-server / Bearer-only OIDC (no browser
+  flow, no consent UI) can flip back to false explicitly. The
+  scaffold comment documents both paths.
+
+- Side note: a follow-up could also flip `services[binding].enabled`
+  to true on dex specifically (since `rda add-service dex auth`
+  is itself an explicit user gesture meaning \"I want this enabled\"),
+  reducing the recipe from 1 manual edit to zero. Not in this PR;
+  out of scope.
+
+- Spec library-chart version 0.11.36 → 0.11.37.

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -557,8 +557,18 @@ charts:
           # `services[].ingress.host` (or in-cluster URL when no ingress)
           # by `derived_values:` above. Devs who need an external SSO
           # issuer override can set `services[].issuer:` manually.
+          #
+          # Ingress.enabled defaults to TRUE for dex (overriding the
+          # convention used for postgres/redis/etc which default false).
+          # Without it, the binding-secret's `public_url` falls back to
+          # the in-cluster URL `http://<release>-dex:5556` which the
+          # BROWSER cannot reach — every browser-side OIDC flow then
+          # redirects to that unreachable URL and stalls. The other
+          # bindings (postgres etc) are pod-internal so their default
+          # of `ingress.enabled: false` is correct.
           ingress.enabled:
-            default: false
+            default: true
+            comment: "dex needs ingress for browser OIDC; flip to false only for pure server-to-server / Bearer use"
           ingress.host:
             default: "{{.Binding}}.{{.ProjectName}}.localtest.me"
             comment: "or use <binding>.<release>.localhost on macOS/Linux"

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -40,7 +40,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.36
+  version: 0.11.37
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled


### PR DESCRIPTION
## Bug — last friction in the 'OIDC dev-ready in 2 commands' promise

Pre-fix, `rda add-service dex auth` scaffolded `services[binding=auth].ingress.enabled: false` by default. Without ingress, the binding-secret's `public_url` falls back to the in-cluster URL `http://<release>-dex:5556` — which the BROWSER cannot reach. Every browser-side OIDC flow redirects to that unreachable URL and stalls.

The dev had to manually flip BOTH:

- `services[binding=auth].enabled: true`         (well-known, scaffold comment hints at it)
- `services[binding=auth].ingress.enabled: true` (silent killer — no hint)

The second flip was the silent killer. Devs flip `enabled` and forget `ingress.enabled`; the pod boots, dex is healthy, the binding-secret is wired, the env vars are projected, but every browser request to `/login` or `/` (post 0.11.35 server-side gate) redirects to `test-dex:5556` which the browser can't reach.

## Fix

dex's scaffold entry now defaults `ingress.enabled: true` with a comment explaining why dex is special-cased. All other bindings (postgres/redis/mariadb/etc) keep `ingress.enabled: false` as default — they're pod-internal, no browser involved.

## Why dex-specific (not all bindings)

postgres/redis/mariadb/grafana/etc are pod-internal: apps reach them via `<BINDING>_HOST` (in-cluster Service URL), no browser involved. Their default `ingress.enabled: false` is correct.

dex is the only bundled service whose flow REQUIRES the browser to reach it — hence the special-case default.

Devs who want server-to-server / Bearer-only OIDC (no browser flow, no consent UI) can flip back to false explicitly. The scaffold comment documents both paths.

## Migration

Existing projects with explicit `ingress.enabled: false` on dex keep that value (scaffold defaults only fill empty positions). The next `rda add-service dex` will scaffold true on a freshly-added binding.

## Spec changes

- library-chart 0.11.36 → 0.11.37
- rda-bundle.yaml manifest version 0.11.36 → 0.11.37
- New MILESTONE: 0.11.37 in library-chart/SPEC.md