### PR TITLE
revert(dex/scaffold): drop bootstrap.auth.users/clients pre-fill (0.11.37)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.11.37
+version: 0.11.38
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -1088,3 +1088,56 @@ Status: in-progress
   out of scope.
 
 - Spec library-chart version 0.11.36 → 0.11.37.
+
+## MILESTONE: 0.11.38
+
+- REVERT (partial of 0.11.32 + revert of 0.11.37): the dex scaffold
+  is reverted to its pre-0.11.32 shape on two points:
+
+  1. `bootstrap.auth.users` and `bootstrap.auth.clients` pre-fill is
+     removed. These pre-filled credentials (`dev@example.com / dev`,
+     `<project>-client / dev-secret`) made the demo work in 2
+     commands but introduced 3 real problems:
+
+     - **Pedagogy lost**: devs never discover `rda bootstrap
+       auth.users add` because the project "just works".
+     - **Dev→prod anti-pattern**: pre-filled `staticPasswords` is
+       dev-only and dex-specific. In prod, auth uses connectors +
+       ExternalSecrets.
+     - **Multi-provider incoherence**: `bootstrap.auth.users` is a
+       generic capability, but the pre-fill content is dex-specific.
+       Keycloak users live in a realm; github oauth users are
+       external. Pre-filling ties the scaffold to a single backend.
+
+  2. `ingress.enabled: default: true` (added in 0.11.37) reverts to
+     `false` — consistent with all other bindings. Devs flip it
+     explicitly to true when they want browser-side OIDC, with a
+     scaffolded comment that explains the contract.
+
+- The recommended dev workflow is now **explicit gestures**:
+
+      rda new myapp --template web-go
+      cd myapp
+      rda add-service dex auth
+      # in deploy/values.yaml, flip:
+      #   services[binding=auth].enabled: true
+      #   services[binding=auth].ingress.enabled: true
+      rda bootstrap auth.users add <email> --field password=<pw>
+      # auth.clients still requires yq for redirectURIs (list-typed
+      # field — rda-cli issue: support list --field). For dex:
+      yq -i '...bootstrap.auth.clients = [...]' deploy/values.yaml
+      tilt up
+
+  See `concepts/capabilities.md` (the three-tier DSL surface:
+  hardcoded / capabilities / passthrough) and `concepts/auth.md`.
+
+- KEPT from 0.11.32:
+  - `passthrough.config.oauth2.passwordConnector: local` — legitimate
+    dex-specific config on the verbatim escape hatch.
+  - `binding_secret` keys `client_id` / `client_secret` /
+    `redirect_uri` — proto-contract for the future `category:
+    auth.oidc` formalisation.
+  - All template fixes (Procfile absolute path, OIDC env name
+    alignment, server-side gate on `/`, ingress port.number).
+
+- Spec library-chart version 0.11.37 → 0.11.38.

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -558,17 +558,21 @@ charts:
           # by `derived_values:` above. Devs who need an external SSO
           # issuer override can set `services[].issuer:` manually.
           #
-          # Ingress.enabled defaults to TRUE for dex (overriding the
-          # convention used for postgres/redis/etc which default false).
-          # Without it, the binding-secret's `public_url` falls back to
-          # the in-cluster URL `http://<release>-dex:5556` which the
-          # BROWSER cannot reach — every browser-side OIDC flow then
-          # redirects to that unreachable URL and stalls. The other
-          # bindings (postgres etc) are pod-internal so their default
-          # of `ingress.enabled: false` is correct.
+          # ingress.enabled defaults to false (consistent with all other
+          # bindings — postgres, redis, mariadb, etc are pod-internal so
+          # don't need ingress). DEX is the exception: when the project
+          # uses BROWSER-side OIDC, the dev MUST flip this to true so the
+          # binding-secret's `public_url` carries the ingress URL, not
+          # the in-cluster fallback. The recommended workflow:
+          #
+          #   rda add-service dex auth
+          #   # in deploy/values.yaml: flip enabled + ingress.enabled
+          #   rda bootstrap auth.users add <email> --field password=<pw>
+          #
+          # See concepts/auth.md and concepts/capabilities.md for the
+          # explicit-gestures workflow.
           ingress.enabled:
-            default: true
-            comment: "dex needs ingress for browser OIDC; flip to false only for pure server-to-server / Bearer use"
+            default: false
           ingress.host:
             default: "{{.Binding}}.{{.ProjectName}}.localtest.me"
             comment: "or use <binding>.<release>.localhost on macOS/Linux"
@@ -610,27 +614,13 @@ charts:
           passthrough.config.oauth2.passwordConnector:
             default: local
             comment: "connector for password-grant; flip to '' if you only want browser flow"
-          # ─── Bootstrap-data defaults (Phase 2.4 of DO 0001) ────
-          # Pre-fills one dev user + one OIDC client so a fresh
-          # `rda new <p> && cd <p> && rda add-service dex auth &&
-          # tilt up` produces a working OIDC chain WITHOUT any
-          # manual values.yaml edit. Devs edit / replace these
-          # before promoting to staging+ (production: connectors,
-          # ExternalSecrets, real users — see concepts/auth.md).
-          bootstrap:
-            comment: "dev bootstrap data — replace before staging+"
-            default:
-              auth.users:
-                - name: dev@example.com
-                  password: dev
-              auth.clients:
-                - id: "{{.ProjectName}}-client"
-                  secret: dev-secret
-                  name: "{{.ProjectName}}"
-                  redirectURIs:
-                    - "http://{{.ProjectName}}.localtest.me/auth/callback"
-                    # second URL for `kubectl port-forward 18081:80` flow
-                    - "http://localhost:18081/auth/callback"
+          # NOTE: `bootstrap.auth.users` and `bootstrap.auth.clients`
+          # are NOT pre-filled. The dev declares them explicitly via
+          # `rda bootstrap auth.users add ...` (typed CLI) or by
+          # editing `services[binding=auth].bootstrap.*` directly.
+          # This avoids burying default credentials (dev/dev) in
+          # scaffolded yaml where they easily survive into staging.
+          # See concepts/auth.md for the recommended workflow.
 
         # ─── Capabilities (Phase 2 of DO 0001-A) ───────────────────
         # Bootstrap-data the dex chart accepts: a typed list of users

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -40,7 +40,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.11.37
+  version: 0.11.38
 
 # Catalogue surfaced by the library chart. Each AppCo chart is referenced
 # by its real name (no alias). The local_chart_ref points at the bundled


### PR DESCRIPTION
## Why this revert

The pre-filled `bootstrap.auth.users` / `bootstrap.auth.clients` introduced in 0.11.32 (PR #120) made `rda new + rda add-service dex auth + tilt up` work end-to-end without any explicit gesture. Wins for the demo, three real losses:

1. **Pedagogy lost** — devs never discover `rda bootstrap auth.users add` because the project 'just works'. The typed CLI becomes invisible.

2. **Dev→prod anti-pattern** — pre-filled `staticPasswords` is dev-only and dex-specific. In prod, auth uses connectors (github/ldap/oidc) + ExternalSecrets. The pre-fill teaches a pattern that has to be unlearned.

3. **Multi-provider incoherence** — `bootstrap.auth.users` is a generic capability across providers, but the pre-fill content (`name`/`password`) only makes sense for dex. Keycloak users live in a realm; github oauth users are external accounts. Pre-filling ties the scaffold to a single backend.

## Recommended dev workflow now

```
rda new myapp --template web-go
cd myapp
rda add-service dex auth
# in deploy/values.yaml, flip:
#   services[binding=auth].enabled: true
#   services[binding=auth].ingress.enabled: true
rda bootstrap auth.users add dev@example.com --field password=dev
yq -i '...bootstrap.auth.clients = [...]' deploy/values.yaml
tilt up
```

`auth.clients` still requires yq for the `redirectURIs` list field — rda-cli issue to track: support list-typed `--field` flags.

## Kept from 0.11.32

- `passthrough.config.oauth2.passwordConnector: local` default — legitimate dex-specific config on the verbatim escape hatch.
- `binding_secret` keys `client_id` / `client_secret` / `redirect_uri` — alignment of the contract between bundle (what the binding-secret exposes) and templates (what the app reads). Proto-contract for the future `category: auth.oidc` formalisation.

## Companion work

- rda-e2e-tests scenario 21 will be rewritten to exercise the explicit-gesture workflow (separate PR).
- rda-docs `concepts/auth.md` + `concepts/dsl.md` updated to document the three-tier DSL surface (hardcoded / capabilities / passthrough) (separate PR).

## Spec changes

- library-chart 0.11.36 → 0.11.37
- rda-bundle.yaml 0.11.36 → 0.11.37