### PR TITLE
fix(tests): wrap env-aliases fixture under workloads_resolved[]

### DIFF
--- a/library-chart/tests/env-aliases/01-env-resolved-renders-both-secret-and-value.values.yaml
+++ b/library-chart/tests/env-aliases/01-env-resolved-renders-both-secret-and-value.values.yaml
@@ -28,23 +28,32 @@ postgresql:
 # Mimics `rda render` output: 4 secret-ref env vars (the pure refs the
 # dev wrote in suse-library.env) + 1 literal value (a composed URL
 # the dev wrote with embedded ${binding:...} substitutions).
-env_resolved:
-  - name: DB_HOST
-    kind: secret
-    secretRef: demo-db-binding
-    secretKey: host
-  - name: DB_USER          # The dev's chosen alias of `username` — no
-    kind: secret           # more env_aliases magic; explicit in env block.
-    secretRef: demo-db-binding
-    secretKey: username
-  - name: DB_USERNAME      # Same key, different env-var name (SBS
-    kind: secret           # canonical). Both refs are valid; the dev
-    secretRef: demo-db-binding   # picks which they want.
-    secretKey: username
-  - name: DB_PASSWORD
-    kind: secret
-    secretRef: demo-db-binding
-    secretKey: password
-  - name: DATABASE_URL
-    kind: value
-    value: "postgres://app:pw@demo-db-postgresql:5432/demo"
+#
+# After the Phase 2 workloads-dsl refactor, deployment.yaml iterates
+# `.Values.workloads_resolved[].env_resolved`, so the env list lives
+# under a workload entry rather than at the top level.
+workloads_resolved:
+  - name: web
+    image:
+      repository: nginx
+      tag: latest
+    env_resolved:
+      - name: DB_HOST
+        kind: secret
+        secretRef: demo-db-binding
+        secretKey: host
+      - name: DB_USER          # The dev's chosen alias of `username` — no
+        kind: secret           # more env_aliases magic; explicit in env block.
+        secretRef: demo-db-binding
+        secretKey: username
+      - name: DB_USERNAME      # Same key, different env-var name (SBS
+        kind: secret           # canonical). Both refs are valid; the dev
+        secretRef: demo-db-binding   # picks which they want.
+        secretKey: username
+      - name: DB_PASSWORD
+        kind: secret
+        secretRef: demo-db-binding
+        secretKey: password
+      - name: DATABASE_URL
+        kind: value
+        value: "postgres://app:pw@demo-db-postgresql:5432/demo"


### PR DESCRIPTION
## Summary
- Wrap the env-aliases smoke-test fixture's `env_resolved` list under a `workloads_resolved[].env_resolved` entry so it matches the post–Phase 2 deployment template, which iterates `.Values.workloads_resolved[]`.
- `services:` and `postgresql:` stay at the top level — they're chart-level, not per-workload.

## Why
After the Phase 2 workloads-dsl refactor (commit 80bf862), `deployment.yaml` no longer reads top-level `env_resolved` — it ranges over `.Values.workloads_resolved[].env_resolved`. The fixture wasn't migrated, so all 7 env-emission checks in `library-chart/tests/env-aliases/run.sh` reported `✗ missing`.

## Test plan
- [x] `bash library-chart/tests/env-aliases/run.sh` → `Results: 8 passed, 0 failed` (was 1 passed, 7 failed before the change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)