### PR TITLE
fix: make apache-airflow metadb/broker dependencies optional

### DIFF
--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -1495,9 +1495,16 @@ charts:
         chart_defaults:
           apache-airflow.postgresql.enabled: false
           apache-airflow.redis.enabled: false
+        # metadb and broker are NOT required: chart_defaults above already
+        # disable the embedded postgresql / redis sub-charts, so airflow
+        # renders cleanly even when the dev hasn't wired them yet (no
+        # duplicate Secret on shared namespaces with a standalone cnpg/
+        # postgresql/redis). The dev still needs to wire them before the
+        # pod starts — `rda doctor` and the scaffold hints flag that —
+        # but `rda render` no longer blocks a partial configuration.
         dependencies:
           - charts: [postgresql, cnpg]
-            required: true
+            required: false
             dsl_field: metadb
             wiring:
               apache-airflow.postgresql.enabled: __literal:false
@@ -1507,7 +1514,7 @@ charts:
               apache-airflow.data.metadataConnection.pass: auth.user.password
               apache-airflow.data.metadataConnection.db: auth.user.database
           - charts: [redis]
-            required: true
+            required: false
             dsl_field: broker
             wiring:
               apache-airflow.redis.enabled: __literal:false


### PR DESCRIPTION
## Summary

- Marks `apache-airflow.dependencies.metadb` and `.broker` as `required: false`.
- `chart_defaults` already disables the embedded `postgresql` / `redis` sub-charts, so omitting wiring is safe at render time.
- Unblocks `rda-e2e-tests` scenario 134 (`airflow-no-duplicate-secrets`) which previously failed at the `rda render` required-dep check.

## Why

Adding `apache-airflow` without wiring `metadb` or `broker` made `rda render` fail loud. Since `chart_defaults` already turn off the embedded postgresql/redis sub-charts (so no duplicate Secret can land in a shared namespace with a standalone cnpg/postgresql/redis), blocking render is overly strict. `rda doctor` and the scaffold hints still nudge the dev to wire both before tilt-up.

## Test plan

- [ ] `rda new <app> --template web-nodejs` followed by `rda service add apache-airflow pipeline --set enabled=true --set auth.user.password=test` should now render cleanly (no `requires a postgresql/cnpg service for "metadb"` error).
- [ ] `rda render` on a project with both `cnpg` and `apache-airflow` (no metadb/broker wired) produces an overlay with `apache-airflow.postgresql.enabled: false` and `apache-airflow.redis.enabled: false`.
- [ ] `helm template` against that overlay shows no duplicate `kind: Secret` / `metadata.name` pairs.