### PR TITLE
feat(dex): env_inject for state_db wiring (0.11.39)

### DIFF
--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -1141,3 +1141,31 @@ Status: in-progress
     alignment, server-side gate on `/`, ingress port.number).
 
 - Spec library-chart version 0.11.37 → 0.11.38.
+
+## MILESTONE: 0.11.39
+
+- DEX state_db wiring switches to **env_inject** for both postgresql
+  and mariadb dependency entries. Adds `env_inject: dex.env` to the
+  two `dependencies` entries under the dex chart in
+  `library-chart/dsl-mappings.yaml`.
+
+- Why: with `provisioning: connect` + `credentials.secretRef`, the
+  prior wiring depended on a kubectl read of the external Secret at
+  render time. When the cluster was unreachable or the Secret hadn't
+  been applied yet (e.g. cold-start staging, CI render-only smoke),
+  the read silently failed and dex got baked literal values from the
+  in-cluster chart default — leaving it hitting the wrong postgres
+  IP after a binding switched from `deploy` to `connect`.
+
+- How env_inject works (requires render-engine v0.7.0+): when set
+  AND the source binding exposes a K8s Secret (secretRef OR auto-
+  generated binding-secret in `provisioning: deploy`), each wiring
+  target gets a `$RDA_DEP_<FIELD>_<KEY>` placeholder and a matching
+  secretKeyRef env entry is appended at the target's env list
+  (here: `dex.env`). dex's config-file env expansion resolves the
+  placeholders at pod start, matching how workload
+  `${binding:NAME.field}` env refs already work. Sentinels that
+  don't map to a single secret key (`__literal:`,
+  `__bootstrap:`, `__url__/suffix`) keep render-time literal baking.
+
+- Spec library-chart version 0.11.38 → 0.11.39.

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -667,10 +667,24 @@ charts:
         # the external postgresql connection. Without this field, dex uses
         # in-memory storage (the scaffold default) — fine for dev, not for
         # staging/prod where dex state must survive restarts.
+        #
+        # env_inject: dex.env — host/port/credentials are injected as
+        # secretKeyRef env vars on the dex container (one per wiring
+        # target). The wiring targets are written as `$RDA_DEP_STATE_DB_*`
+        # placeholders that dex's config-file env expansion resolves at
+        # pod start. Critical for `provisioning: connect` with secretRef:
+        # without env_inject the wiring depended on a kubectl read of the
+        # external Secret at render time — silent fallback to the in-
+        # cluster default left dex hitting the old in-cluster postgres
+        # IP when the user switched a postgres binding from deploy to
+        # connect. With env_inject the dex pod reads shared-pg directly
+        # at start, matching how workload `${binding:db.host}` env refs
+        # already work via secretKeyRef.
         dependencies:
           - charts: [postgresql, cnpg]
             required: false
             dsl_field: state_db
+            env_inject: dex.env
             wiring:
               dex.config.storage.type: __literal:postgres
               dex.config.storage.config.host: __host_short__
@@ -693,6 +707,7 @@ charts:
           - charts: [mariadb]
             required: false
             dsl_field: state_db
+            env_inject: dex.env
             wiring:
               dex.config.storage.type: __literal:mysql
               dex.config.storage.config.host: __host_short__


### PR DESCRIPTION
## Summary
- Adds `env_inject: dex.env` to both postgresql and mariadb dependency entries on the dex chart in `library-chart/dsl-mappings.yaml`.
- New `MILESTONE: 0.11.39` in `library-chart/SPEC.md` documenting the change and rationale.

## Why
With `provisioning: connect` + `credentials.secretRef`, the prior wiring depended on a kubectl read of the external Secret at render time. When the cluster was unreachable or the Secret hadn't been applied yet, the read silently failed and dex got baked literal values from the in-cluster chart default — leaving it hitting the wrong postgres IP after a binding switched from deploy to connect.

env_inject (render-engine v0.7.0+) writes `\$RDA_DEP_STATE_DB_*` placeholders at each wiring target and appends matching secretKeyRef env entries on `dex.env`. dex's config-file env expansion resolves them at pod start — same robustness as workload `\${binding:NAME.field}` env refs.

## Requires
- rda-render-engine v0.7.0 (DependencySpec.EnvInject)
- rda-cli bumped to v0.7.0 (PR idefxH/rda-cli#150)

## Test plan
- [ ] helm-template-smoke renders dex with `dex.env` containing the 5 secretKeyRef entries
- [ ] e2e scenario with dex + shared-pg via `provisioning: connect` + `secretRef`