### PR TITLE
fix: e2e bugs B5/B6/B13 — cnpg pull-secrets, airflow broker, chart-source gate

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -1516,6 +1516,16 @@ charts:
         chart_defaults:
           apache-airflow.postgresql.enabled: false
           apache-airflow.redis.enabled: false
+          # `data.brokerUrlSecretName` MUST be set or the chart's helm-
+          # template-time `required` check fires with `You must set one
+          # of the values data.brokerUrlSecretName or data.brokerUrl`.
+          # We bake a fixed name here and have the library chart emit
+          # that Secret when a `broker:` binding is wired (see
+          # templates/airflow-broker-secret.yaml). When no broker is
+          # wired the airflow workload won't start anyway (CeleryExecutor
+          # needs a broker), and `rda doctor` flags it — but `helm
+          # template` no longer aborts at the required check.
+          apache-airflow.data.brokerUrlSecretName: airflow-broker-url
         # metadb and broker are NOT required: chart_defaults above already
         # disable the embedded postgresql / redis sub-charts, so airflow
         # renders cleanly even when the dev hasn't wired them yet (no

--- a/library-chart/scripts/chart-source.py
+++ b/library-chart/scripts/chart-source.py
@@ -11,9 +11,21 @@ appco mode: restores the dropped deps by appending entries from
   scripts/appco-overlay.yaml. Idempotent — already-present deps are
   not duplicated.
 
+auto mode: detect whether the local helm registry config has
+  credentials for dp.apps.rancher.io and switch accordingly —
+  community if no credentials, appco if there are. Idempotent; safe
+  to wire into a pre-`helm dep update` hook so CI / fresh clones
+  don't trip on missing AppCo auth.
+
 --check: exit non-zero if appco-overlay.yaml and Chart.yaml have
   drifted (different name/version/repository for any shared dep).
   Used by tests/ to catch a stale overlay before CI does.
+
+--check-resolvable: exit non-zero (with a remediation hint) when
+  Chart.yaml has AppCo OCI deps but no `helm registry login` is in
+  the local helm config for dp.apps.rancher.io. This is the gate
+  CI / dev scripts run BEFORE `helm dep update` to fail fast with a
+  clear message instead of `403 unauthorized` from the registry.
 
 Why this exists:
   `helm dep update` resolves every dependency in Chart.yaml regardless
@@ -25,6 +37,7 @@ Why this exists:
 """
 
 import argparse
+import json
 import os
 import re
 import sys
@@ -44,6 +57,43 @@ CHART_PATH = os.path.join(LIB_DIR, "Chart.yaml")
 OVERLAY_PATH = os.path.join(SCRIPT_DIR, "appco-overlay.yaml")
 
 APPCO_OCI_PREFIX = "oci://dp.apps.rancher.io"
+APPCO_OCI_HOST = "dp.apps.rancher.io"
+
+
+def helm_registry_config_paths() -> List[str]:
+    """Where helm v3 stores OCI registry auth — XDG-honouring, with the
+    macOS Helm fallback (~/Library/Preferences) for completeness."""
+    home = os.path.expanduser("~")
+    xdg_config = os.environ.get("XDG_CONFIG_HOME") or os.path.join(home, ".config")
+    return [
+        os.path.join(xdg_config, "helm", "registry", "config.json"),
+        os.path.join(xdg_config, "helm", "registry.json"),  # older layout
+        os.path.join(home, "Library", "Preferences", "helm", "registry", "config.json"),
+    ]
+
+
+def has_appco_credentials() -> bool:
+    """True if any local helm-registry config has an auth entry for
+    dp.apps.rancher.io. We DON'T verify the token is valid (would
+    require a network call) — presence is a reasonable proxy: a stale
+    token still gives a clearer 401 from the registry than a community
+    user gets today from a missing-creds 403."""
+    for path in helm_registry_config_paths():
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path) as f:
+                doc = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        auths = doc.get("auths") or {}
+        for key in auths:
+            # Helm stores either the bare host or a URL with scheme;
+            # tolerate both.
+            normalized = key.replace("https://", "").replace("http://", "").rstrip("/")
+            if normalized.startswith(APPCO_OCI_HOST):
+                return True
+    return False
 
 
 def load_yaml(path: str) -> dict:
@@ -153,8 +203,16 @@ def go_appco(chart_path: str, chart_text: str, chart: dict, overlay: dict) -> in
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     g = ap.add_mutually_exclusive_group(required=True)
-    g.add_argument("--mode", choices=["community", "appco"], help="Target chart source.")
+    g.add_argument("--mode", choices=["community", "appco", "auto"], help="Target chart source. 'auto' picks based on local AppCo OCI credentials.")
     g.add_argument("--check", action="store_true", help="Verify Chart.yaml and appco-overlay.yaml are in sync.")
+    g.add_argument(
+        "--check-resolvable",
+        action="store_true",
+        help="Fail fast if Chart.yaml has AppCo OCI deps but no local "
+             "helm registry login for dp.apps.rancher.io. Gate this "
+             "BEFORE `helm dep update` for a clear error instead of a "
+             "403 from the registry.",
+    )
     ap.add_argument("--chart", default=CHART_PATH, help="Path to Chart.yaml (default: library-chart/Chart.yaml).")
     ap.add_argument("--overlay", default=OVERLAY_PATH, help="Path to appco-overlay.yaml.")
     args = ap.parse_args()
@@ -177,6 +235,47 @@ def main() -> int:
             return 1
         print("chart-source: appco-overlay.yaml and Chart.yaml are in sync.")
         return 0
+
+    if args.check_resolvable:
+        appco_deps = appco_deps_in(chart)
+        if not appco_deps:
+            print("chart-source: Chart.yaml has no AppCo OCI deps — `helm dep update` will not hit the AppCo registry.")
+            return 0
+        if has_appco_credentials():
+            print(
+                f"chart-source: Chart.yaml has {len(appco_deps)} AppCo OCI dep(s) "
+                f"AND a local helm registry login for {APPCO_OCI_HOST} was found. "
+                f"`helm dep update` should resolve."
+            )
+            return 0
+        sys.stderr.write(
+            f"chart-source: Chart.yaml references {len(appco_deps)} AppCo OCI dep(s) "
+            f"({', '.join(d['name'] for d in appco_deps)}), but no helm registry "
+            f"login for {APPCO_OCI_HOST} was found in the local helm config.\n"
+            f"\n"
+            f"`helm dep update` will fail with a 403/unauthorized from the registry.\n"
+            f"\n"
+            f"Fix one of:\n"
+            f"  - Log in:   helm registry login {APPCO_OCI_HOST}\n"
+            f"  - Or strip: scripts/use-community-charts.sh\n"
+            f"  - Or auto:  python3 library-chart/scripts/chart-source.py --mode auto\n"
+        )
+        return 1
+
+    if args.mode == "auto":
+        appco_deps = appco_deps_in(chart)
+        if has_appco_credentials():
+            if appco_deps:
+                print(f"chart-source: AppCo creds found for {APPCO_OCI_HOST} and Chart.yaml already in appco mode — nothing to do.")
+                return 0
+            print(f"chart-source: AppCo creds found for {APPCO_OCI_HOST}; switching to appco mode.")
+            return go_appco(args.chart, chart_text, chart, overlay)
+        else:
+            if not appco_deps:
+                print(f"chart-source: no AppCo creds for {APPCO_OCI_HOST} and Chart.yaml already in community mode — nothing to do.")
+                return 0
+            print(f"chart-source: no AppCo creds for {APPCO_OCI_HOST}; switching to community mode.")
+            return go_community(args.chart, chart_text, chart)
 
     if args.mode == "community":
         return go_community(args.chart, chart_text, chart)

--- a/library-chart/templates/airflow-broker-secret.yaml
+++ b/library-chart/templates/airflow-broker-secret.yaml
@@ -1,0 +1,79 @@
+{{/*
+  airflow-broker-secret.yaml — derive the Celery broker URL Secret
+  expected by the apache-airflow chart from the wired redis binding.
+
+  Why this template exists:
+    The apache-airflow chart fails its helm-template-time `required` check
+    with `You must set one of the values data.brokerUrlSecretName or
+    data.brokerUrl` whenever its internal redis is disabled
+    (redis.enabled=false — which we default to in dsl-mappings.yaml,
+    so devs can wire an external redis instead of getting two of them).
+
+    dsl-mappings.yaml's chart_defaults sets brokerUrlSecretName to the
+    fixed name `airflow-broker-url`. This template materializes the
+    matching Secret with the chart-expected key `connection`, built
+    from the redis binding the dev pointed at via `broker:`.
+
+  Behavior:
+    - No apache-airflow service in services[]              → no Secret emitted
+    - apache-airflow without `broker:` set                 → no Secret emitted
+      (dev still has to wire one before the pod can start; `rda doctor`
+      flags it. The chart's required check is satisfied by the projected
+      brokerUrlSecretName string, even when the Secret itself is absent
+      at helm-template time — it materialises at apply time when this
+      template fires.)
+    - apache-airflow + broker → matching redis service    → emit Secret
+    - apache-airflow + broker → non-redis or missing      → fail loud
+*/}}
+
+{{- $airflowSvcs := list -}}
+{{- range $svc := (.Values.services | default list) -}}
+  {{- if eq (default "" $svc.type) "apache-airflow" -}}
+    {{- if not (hasKey $svc "enabled") -}}
+      {{- $airflowSvcs = append $airflowSvcs $svc -}}
+    {{- else if $svc.enabled -}}
+      {{- $airflowSvcs = append $airflowSvcs $svc -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- range $i, $airflow := $airflowSvcs -}}
+{{- $brokerBinding := default "" $airflow.broker -}}
+{{- if $brokerBinding -}}
+  {{- $redisSvc := dict -}}
+  {{- range $svc := ($.Values.services | default list) -}}
+    {{- if eq (default "" $svc.binding) $brokerBinding -}}
+      {{- $redisSvc = $svc -}}
+    {{- end -}}
+  {{- end -}}
+  {{- /* Only emit when the broker resolves to a real redis binding.
+         The engine's projectDependencies already validates the
+         relationship at render time (loud error on missing or
+         wrong-type binding); we don't duplicate that here. Skipping
+         silently lets the smoke harness exercise apache-airflow
+         with a placeholder broker name without tripping this
+         template, while real misconfiguration still trips the
+         engine. */ -}}
+  {{- if and $redisSvc.binding (eq (default "" $redisSvc.type) "redis") -}}
+  {{- $pass := "" -}}
+  {{- if $redisSvc.auth -}}{{- if $redisSvc.auth.user -}}
+    {{- $pass = default "" $redisSvc.auth.user.password -}}
+  {{- end -}}{{- end -}}
+  {{- $host := printf "%s-redis" $.Release.Name -}}
+  {{- $port := "6379" -}}
+  {{- $url := printf "redis://:%s@%s:%s/0" $pass $host $port -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-broker-url
+  labels:
+    app.kubernetes.io/managed-by: {{ include "suse-library.labelValue" $.Release.Service }}
+    app.kubernetes.io/instance: {{ include "suse-library.labelValue" $.Release.Name }}
+    rda.suse.com/binding: {{ include "suse-library.labelValue" $airflow.binding }}
+type: Opaque
+stringData:
+  connection: {{ $url | quote }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/library-chart/templates/cnpg-cluster.yaml
+++ b/library-chart/templates/cnpg-cluster.yaml
@@ -33,6 +33,13 @@
 {{- $existingRoles := default list (get $managed "roles") -}}
 {{- $_ := set $managed "roles" (append $existingRoles $role) -}}
 {{- $_ := set $spec "managed" $managed -}}
+{{- /* Propagate top-level imagePullSecrets — the CNPG operator copies
+       spec.imagePullSecrets onto each pod it spawns. Without this the
+       AppCo cnpg image fails with ImagePullBackOff in the rendered
+       cluster, even though chart-managed Deployments get the secret. */ -}}
+{{- if and (not (dig "imagePullSecrets" false $spec)) ($.Values.imagePullSecrets) -}}
+  {{- $_ := set $spec "imagePullSecrets" $.Values.imagePullSecrets -}}
+{{- end -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:


### PR DESCRIPTION
## Summary

Batch fix for e2e bugs surfaced against the rda-opinion-bundle-example. Three real bundle-side bugs (B5, B6, B13) get patches; the two engine-side ones (B4, B12) are no-ops here — verified upstream / already-on-main.

### B5 — cnpg Cluster CR drops `imagePullSecrets`

`library-chart/templates/cnpg-cluster.yaml` now propagates the top-level `imagePullSecrets` onto the `Cluster.spec`. The CNPG operator copies `spec.imagePullSecrets` onto each pod it spawns, so without this the AppCo cnpg image landed in `ImagePullBackOff` even when the chart-managed Deployments got the pull secret. User passthrough on `cluster.imagePullSecrets` is preserved.

### B6 — apache-airflow `data.brokerUrl[SecretName]` required check

apache-airflow's `redis.enabled: false` default (the right default for "wire your own redis") tripped the chart's helm-template-time `required` check with `You must set one of the values data.brokerUrlSecretName or data.brokerUrl`.

Fix is two-part:
- `chart_defaults` bakes a fixed `data.brokerUrlSecretName: airflow-broker-url`.
- A new `templates/airflow-broker-secret.yaml` emits the matching Secret with the chart-canonical key `connection: redis://:<pass>@<host>:6379/0` whenever a redis binding is wired via `broker:`.

When the broker isn't wired (or references a non-redis binding), the Secret is silently skipped so the smoke harness can render apache-airflow with placeholder values; real misconfiguration is still loudly caught by the engine's projectDependencies path.

### B13 — chart-source.py AppCo-OCI gate

`condition:` gates install, not download — `helm dep update` resolves every dep regardless, which fails noisily without AppCo credentials. The script grows two helpers:

- `--mode auto`: picks community vs. appco from the presence of a local helm registry login for `dp.apps.rancher.io`.
- `--check-resolvable`: fails fast (with a remediation hint) before `helm dep update` would otherwise return an opaque 403.

### B4 / B12 — no-op here

- **B4** (`__port__` + env_inject → `EnvVar.name = int`): already fixed in rda-render-engine HEAD (`29ed66e fix: __port__ bypasses env_inject, always resolves as integer`). Bundle wiring already uses `__port__` (per `0f8b64c` on main).
- **B12** (grafana 12.2.1 / influxdb 2.1.2 not in community): already migrated in `45d0728` (grafana 12.2.1 → 10.5.15) and `d791422` (influxdb → influxdb2 alias) on main. Both versions are present at the community repos today.

library-chart Chart.yaml version 0.16.1 → 0.16.2.

## Test plan

- [x] `library-chart/tests/helm-template-smoke` — 21/21 pass (apache-airflow now renders the broker Secret + chart_defaults brokerUrlSecretName)
- [x] `library-chart/tests/dsl-mappings-schema` — pass
- [x] `library-chart/tests/dsl-mappings-target-validity` — pass
- [x] `library-chart/tests/cnpg-initdb-secret` — pass
- [x] `library-chart/tests/values-schema-leaks` — pass
- [x] `library-chart/tests/dep-defaults-presence` — pass
- [x] `library-chart/tests/chart-source-overlay-sync` — pass
- [x] Manual helm template on a `apache-airflow + redis + cnpg + imagePullSecrets` project: `Cluster.spec.imagePullSecrets` set, `airflow-broker-url` Secret emitted with `connection: redis://:redispw@t-redis:6379/0`.
- [ ] Re-run the failing e2e scenarios that surfaced these bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)