### PR TITLE
fix(library-chart): switch CNPG postgres image by active chart source (0.16.2)

### DIFF
--- a/library-chart/Chart.yaml
+++ b/library-chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
 
   See rda-docs/concepts/dsl.md for the full DSL contract.
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: "1.0"
 keywords: [suse, rda, library, service-binding, application-collection]
 home: https://github.com/idefxH/rda-opinion-bundle-example

--- a/library-chart/SPEC.md
+++ b/library-chart/SPEC.md
@@ -1169,3 +1169,62 @@ Status: in-progress
   `__bootstrap:`, `__url__/suffix`) keep render-time literal baking.
 
 - Spec library-chart version 0.11.38 → 0.11.39.
+
+## MILESTONE: 0.11.40
+
+- BUGFIX: CNPG `Cluster.spec.imageName` is now selected by the library
+  chart template, not by a `derived_values` projection. The old
+  projection read `.ChartSource` from the render context; rda-cli's
+  `resolveChartSource()` falls back to `"appco"` when
+  `.rda/project.yaml` doesn't carry `chart_source: community`. Result:
+  a project that flipped Chart.yaml deps via
+  `scripts/use-community-charts.sh` (or the `chart-source.py` script)
+  but never persisted the project-level chart_source still got
+  `imageName: dp.apps.rancher.io/containers/postgresql:17`, which
+  crash-loops the cluster on the **community** CNPG operator with
+  `initdb: could not look up effective user ID 26: user does not exist`
+  (AppCo's postgres image bakes UID 26 that the community operator
+  rejects).
+
+- New mechanism in `templates/cnpg-cluster.yaml`: when no `imageName`
+  is set in `cnpg.cluster` (either via DSL or passthrough), the template
+  inspects `.Values.global.imagePullSecrets` and picks the registry to
+  match:
+    - contains `application-collection` → AppCo
+      (`dp.apps.rancher.io/containers/postgresql`)
+    - otherwise (community baseline) →
+      (`ghcr.io/cloudnative-pg/postgresql`)
+  Tag comes from `cnpg.version.postgresql` (set by `branch:` in the
+  service entry) or defaults to `17`. Explicit overrides via passthrough
+  (`cnpg.cluster.imageName: my-registry/pg:tag`) win, since the
+  template only fills in when the field is empty.
+
+- Why owned by the template, not by `rda render`: the template path
+  has access to the post-merge values (which reflect what `rda upgrade
+  --source <mode>` did to `global.imagePullSecrets`) and works the
+  same way under raw `helm template`. The projection path depended on
+  whether `rda render` ran AND on whether the user persisted
+  chart_source. The bundle now owns this contract end-to-end.
+
+- Removed the `cnpg.cluster.imageName` entry from
+  `derived_values:` under `cnpg` in `library-chart/dsl-mappings.yaml`.
+  The `bootstrap.initdb.secret.name` derivation stays — that one only
+  needs `.Release.Name` and `.Binding`, both unambiguous.
+
+- TESTS:
+  - `tests/cnpg-image-source-switch/` (new): renders the CNPG template
+    with 6 value shapes (community baseline; AppCo via `- name:` map;
+    AppCo via bare string; community + `cnpg.version.postgresql: "16"`;
+    explicit `imageName` override; explicit override + AppCo signal)
+    and asserts the rendered `imageName` matches the expected
+    registry/tag. Guards regression in both directions.
+
+- DEPENDENCY: e2e harness (rda-e2e-tests) must extend scenario
+  coverage to exercise BOTH chart sources (community via
+  `scripts/use-community-charts.sh`, appco via the AppCo OCI baseline)
+  for any scenario that wires a CNPG cluster. Single-mode coverage
+  hides this exact class of bug. Tracking under
+  rda-e2e-tests follow-up. Until that lands, the bundle test
+  `cnpg-image-source-switch` is the only safety net.
+
+- Spec library-chart version 0.11.39 → 0.11.40.

--- a/library-chart/dsl-mappings.yaml
+++ b/library-chart/dsl-mappings.yaml
@@ -1687,8 +1687,17 @@ charts:
     # No sub-chart source switching — the Cluster CR is rendered by the
     # library chart template (cnpg-cluster.yaml). The operator dep
     # (cloudnative-pg) is switched by rewriteChartRepos separately.
-    # Image switching (community ghcr.io vs AppCo dp.apps.rancher.io)
-    # is handled via derived_values imageName.
+    # Image switching (community ghcr.io/cloudnative-pg/postgresql vs
+    # AppCo dp.apps.rancher.io/containers/postgresql) lives IN the
+    # library chart template: cnpg-cluster.yaml inspects
+    # `.Values.global.imagePullSecrets` and picks the matching registry
+    # when `imageName` is not user-overridden. Doing it in the template
+    # (not via derived_values) makes it independent of whether
+    # `rda render` ran or whether `.rda/project.yaml` has chart_source
+    # persisted — `helm template` alone produces the right image.
+    # The community image is REQUIRED with the community CNPG operator:
+    # AppCo postgresql:17 uses UID 26 which `initdb` rejects on the
+    # community operator with `could not look up effective user ID 26`.
     default_branch: "17"
     branches:
       "17": {}
@@ -1719,10 +1728,6 @@ charts:
         derived_values:
           - target: cnpg.cluster.bootstrap.initdb.secret.name
             template: "{{ .Release.Name }}-{{ .Binding }}-binding"
-          - target: cnpg.cluster.imageName
-            template: >-
-              {{ if eq .ChartSource "appco" }}dp.apps.rancher.io/containers/postgresql{{ else }}ghcr.io/cloudnative-pg/postgresql{{ end }}:{{ with .Service.branch }}{{ . }}{{ else }}17{{ end }}
-            skip_if: imageName
         chart_defaults:
           cnpg.cluster.instances: 1
           cnpg.cluster.affinity: {}

--- a/library-chart/templates/cnpg-cluster.yaml
+++ b/library-chart/templates/cnpg-cluster.yaml
@@ -6,6 +6,15 @@
   Two safety layers guarantee password synchronization:
   1. bootstrap.initdb.secret.name always set → correct password at bootstrap
   2. managed.roles → continuous reconciliation from binding secret
+
+  Image selection is performed HERE (not via derived_values) so that
+  `helm template` alone yields the correct image regardless of whether
+  `rda render` ran or whether `.rda/project.yaml` has chart_source
+  persisted. Signal: `global.imagePullSecrets` containing
+  `application-collection` ⇒ AppCo registry; otherwise community
+  (ghcr.io/cloudnative-pg/postgresql). The community CNPG operator
+  rejects the AppCo image (`initdb: could not look up effective user
+  ID 26`), so a wrong choice here crash-loops the cluster pod.
 */}}
 {{- $cnpg := .Values.cnpg | default dict -}}
 {{- if $cnpg.enabled }}
@@ -26,6 +35,30 @@
   {{- $_ := set $initdb "secret" (dict "name" $secretName) -}}
   {{- $_ := set $bootstrap "initdb" $initdb -}}
   {{- $_ := set $spec "bootstrap" $bootstrap -}}
+{{- end -}}
+{{- /* Image selection: pick AppCo vs community registry from
+       global.imagePullSecrets unless the user pinned an imageName
+       explicitly (via passthrough or values_mapping). */ -}}
+{{- if not (dig "imageName" "" $spec) -}}
+  {{- $branch := dig "version" "postgresql" "17" $cnpg -}}
+  {{- if not $branch -}}{{- $branch = "17" -}}{{- end -}}
+  {{- $isAppco := false -}}
+  {{- $global := default dict .Values.global -}}
+  {{- range (default list (get $global "imagePullSecrets")) -}}
+    {{- $entry := . -}}
+    {{- if kindIs "map" $entry -}}
+      {{- if eq (default "" (get $entry "name")) "application-collection" -}}
+        {{- $isAppco = true -}}
+      {{- end -}}
+    {{- else -}}
+      {{- if eq (toString $entry) "application-collection" -}}
+        {{- $isAppco = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $registry := "ghcr.io/cloudnative-pg/postgresql" -}}
+  {{- if $isAppco -}}{{- $registry = "dp.apps.rancher.io/containers/postgresql" -}}{{- end -}}
+  {{- $_ := set $spec "imageName" (printf "%s:%s" $registry (toString $branch)) -}}
 {{- end -}}
 {{- /* Layer 2: managed.roles — continuous password reconciliation */ -}}
 {{- $role := dict "name" $owner "ensure" "present" "login" true "passwordSecret" (dict "name" $secretName) -}}

--- a/library-chart/tests/README.md
+++ b/library-chart/tests/README.md
@@ -1,6 +1,6 @@
 # Library Chart Tests
 
-19 invariant test suites that guard the library chart's contracts.
+20 invariant test suites that guard the library chart's contracts.
 Run all: `for d in */; do bash "$d/run.sh"; done`
 
 | Test | What it guards |
@@ -10,6 +10,7 @@ Run all: `for d in */; do bash "$d/run.sh"; done`
 | `binding-secret-multiport-render` | Multi-port binding projection |
 | `catalog-consistency` | dsl-mappings ↔ rda-docs catalog parity |
 | `chart-source-overlay-sync` | appco-overlay.yaml ↔ Chart.yaml AppCo block parity |
+| `cnpg-image-source-switch` | CNPG postgres image matches active chart source |
 | `dep-defaults-presence` | Every Chart.yaml dep has `<name>.enabled: false` in values.yaml |
 | `dsl-mappings-schema` | YAML schema validation of dsl-mappings.yaml |
 | `dsl-mappings-target-validity` | values_mapping targets exist |

--- a/library-chart/tests/cnpg-image-source-switch/run.sh
+++ b/library-chart/tests/cnpg-image-source-switch/run.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# cnpg-image-source-switch — verify the CNPG Cluster template picks the
+# right postgres image for community vs AppCo chart source, and honors
+# an explicit imageName override and a postgres-branch override.
+#
+# Background (idefxH/rda-opinion-bundle-example#?): with the community
+# CNPG operator, the AppCo image (UID 26) makes initdb crash with
+#   initdb: could not look up effective user ID 26: user does not exist
+# so the image selection MUST match the active chart source.
+#
+# Signal used by the template: presence of `application-collection`
+# in `.Values.global.imagePullSecrets` ⇒ AppCo registry; otherwise
+# community (ghcr.io/cloudnative-pg/postgresql).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "SKIP: helm not on PATH, skipping cnpg-image-source-switch"
+  exit 0
+fi
+
+WORK="$(mktemp -d -t cnpg-image-switch.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/deploy/templates" "$WORK/deploy/charts"
+ln -s "$LIB" "$WORK/deploy/charts/suse-library"
+touch "$WORK/deploy/templates/.gitkeep"
+cat > "$WORK/deploy/Chart.yaml" <<EOF
+apiVersion: v2
+name: test
+version: 0.1.0
+type: application
+dependencies:
+  - name: suse-library
+    version: "*"
+    repository: file://charts/suse-library
+EOF
+
+emit_values () {
+  # $1 = ips-shape (none|map|string)
+  # $2 = optional branch (e.g. "16") or empty
+  # $3 = optional explicit imageName override or empty
+  local shape="$1" branch="$2" override="$3" ipsblock="" branchblock="" overrideblock=""
+  case "$shape" in
+    none)   ipsblock=$'  global:\n    imagePullSecrets: []' ;;
+    map)    ipsblock=$'  global:\n    imagePullSecrets:\n      - name: application-collection' ;;
+    string) ipsblock=$'  global:\n    imagePullSecrets:\n      - application-collection' ;;
+  esac
+  if [ -n "$branch" ]; then
+    branchblock=$'    version:\n      postgresql: "'"$branch"$'"'
+  fi
+  if [ -n "$override" ]; then
+    overrideblock="      imageName: $override"
+  fi
+  cat <<EOF
+suse-library:
+  name: test
+  domain: localtest.me
+$ipsblock
+  services:
+    - binding: db
+      type: cnpg
+      enabled: true
+      auth:
+        user:
+          password: testpass
+  cnpg:
+    enabled: true
+$branchblock
+    cluster:
+      instances: 1
+$overrideblock
+      storage:
+        size: 1Gi
+      bootstrap:
+        initdb:
+          database: app
+          owner: app
+EOF
+}
+
+render () {
+  helm template test "$WORK/deploy" -f "$WORK/deploy/values.yaml" \
+    --show-only charts/suse-library/templates/cnpg-cluster.yaml 2>/dev/null \
+    | grep -E '^[[:space:]]+imageName:' | awk '{print $2}' | tr -d '"'
+}
+
+fail=0
+expect () {
+  local label="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    echo "  ✓ $label → $got"
+  else
+    echo "  ✗ $label → got=$got want=$want"
+    fail=$((fail+1))
+  fi
+}
+
+# 1. Community baseline (empty global.imagePullSecrets) → ghcr.io image
+emit_values none "" "" > "$WORK/deploy/values.yaml"
+expect "community (empty list)" "$(render)" "ghcr.io/cloudnative-pg/postgresql:17"
+
+# 2. AppCo (map shape: - name: application-collection) → dp.apps.rancher.io
+emit_values map "" "" > "$WORK/deploy/values.yaml"
+expect "appco (map shape)" "$(render)" "dp.apps.rancher.io/containers/postgresql:17"
+
+# 3. AppCo (string shape: - application-collection) → dp.apps.rancher.io
+emit_values string "" "" > "$WORK/deploy/values.yaml"
+expect "appco (string shape)" "$(render)" "dp.apps.rancher.io/containers/postgresql:17"
+
+# 4. Branch override flows through (community + postgresql: 16)
+emit_values none 16 "" > "$WORK/deploy/values.yaml"
+expect "community + branch=16" "$(render)" "ghcr.io/cloudnative-pg/postgresql:16"
+
+# 5. Explicit imageName override wins over both registry and branch
+emit_values none 16 "my-registry.example.com/pg:custom" > "$WORK/deploy/values.yaml"
+expect "explicit imageName preserved" "$(render)" "my-registry.example.com/pg:custom"
+
+# 6. Explicit override survives even in AppCo mode
+emit_values map "" "my-registry.example.com/pg:custom" > "$WORK/deploy/values.yaml"
+expect "explicit override beats appco signal" "$(render)" "my-registry.example.com/pg:custom"
+
+if [ "$fail" -gt 0 ]; then
+  echo "FAIL: $fail case(s) failed"
+  exit 1
+fi
+echo "✓ cnpg-image-source-switch: 6 cases passed"

--- a/rda-bundle.yaml
+++ b/rda-bundle.yaml
@@ -110,7 +110,7 @@ library_chart:
   # production implementation supports file:// URIs only — see the v1-gap
   # issue tracking oci:// support.
   oci_ref: file://library-chart
-  version: 0.16.0
+  version: 0.16.2
 # Tilt extension version. Injected into scaffolded Tiltfiles at
 # `rda new` time. `rda upgrade` bumps existing Tiltfiles when this
 # changes. Single source of truth for the extension ref — templates


### PR DESCRIPTION
## Summary

The community CNPG operator rejects AppCo's `postgresql:17` (UID 26) with:

```
initdb: could not look up effective user ID 26: user does not exist
```

The old image derivation lived in `dsl-mappings` `derived_values` and read `.ChartSource` from the render context, which rda-cli's `resolveChartSource()` defaults to `"appco"` when `.rda/project.yaml` has no `chart_source` persisted. So flipping Chart.yaml deps via `scripts/use-community-charts.sh` alone leaves the AppCo image baked in and the cluster pod crashes on the community operator.

**Fix:** move image selection into `templates/cnpg-cluster.yaml`. When no `imageName` is set, detect community vs AppCo from `.Values.global.imagePullSecrets` (presence of `application-collection` ⇒ AppCo, otherwise community) and pick the matching registry. Explicit `imageName` overrides via passthrough win.

## Changes

- `library-chart/templates/cnpg-cluster.yaml` — new image-selection block (handles both list shapes: `- name:` map and bare string)
- `library-chart/dsl-mappings.yaml` — remove the `cnpg.cluster.imageName` `derived_values` entry (chart now owns it); update header comment
- `library-chart/tests/cnpg-image-source-switch/` — new test, 6 cases:
  1. community baseline → `ghcr.io/cloudnative-pg/postgresql:17`
  2. AppCo via `- name:` map → `dp.apps.rancher.io/containers/postgresql:17`
  3. AppCo via bare string → `dp.apps.rancher.io/containers/postgresql:17`
  4. community + branch=16 → `ghcr.io/cloudnative-pg/postgresql:16`
  5. explicit `imageName` preserved
  6. explicit override beats AppCo signal
- `library-chart/Chart.yaml` + `rda-bundle.yaml`: 0.16.1 → 0.16.2 (manifest-version-sync now in sync — previous bump left manifest at 0.16.0)
- `library-chart/SPEC.md` — MILESTONE 0.11.40 documents the bug + fix
- `library-chart/tests/README.md` — register new test

## E2E follow-up needed

`rda-e2e-tests` should exercise **both** community and AppCo modes for any scenario that wires a CNPG cluster. Single-mode coverage hid this exact class of bug — see SPEC milestone for tracking.

## Test plan

- [x] `library-chart/tests/cnpg-image-source-switch/run.sh` — 6/6 cases pass
- [x] `library-chart/tests/cnpg-initdb-secret/run.sh` — initdb secret derivation still wired
- [x] `library-chart/tests/manifest-version-sync/run.sh` — Chart.yaml ↔ rda-bundle.yaml in sync at 0.16.2
- [x] `library-chart/tests/dsl-mappings-schema/run.sh` + `dsl-mappings-target-validity/run.sh` pass
- [x] All other library-chart tests pass (one pre-existing unrelated `web-java-gradle` failure: missing Gradle Wrapper)
- [ ] End-to-end: project with community charts + cnpg binding bootstraps successfully (community image used, no UID 26 crash)
- [ ] End-to-end: project with AppCo charts + cnpg binding bootstraps successfully (AppCo image used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)