### PR TITLE
test: guard cnpg operator + CRDs bundled as sub-chart

### DIFF
--- a/library-chart/tests/README.md
+++ b/library-chart/tests/README.md
@@ -1,6 +1,6 @@
 # Library Chart Tests
 
-20 invariant test suites that guard the library chart's contracts.
+21 invariant test suites that guard the library chart's contracts.
 Run all: `for d in */; do bash "$d/run.sh"; done`
 
 | Test | What it guards |
@@ -11,6 +11,7 @@ Run all: `for d in */; do bash "$d/run.sh"; done`
 | `catalog-consistency` | dsl-mappings ↔ rda-docs catalog parity |
 | `chart-source-overlay-sync` | appco-overlay.yaml ↔ Chart.yaml AppCo block parity |
 | `cnpg-image-source-switch` | CNPG postgres image matches active chart source |
+| `cnpg-operator-bundled` | CNPG operator + CRDs ship as sub-chart so `helm install` works without Tilt |
 | `dep-defaults-presence` | Every Chart.yaml dep has `<name>.enabled: false` in values.yaml |
 | `dsl-mappings-schema` | YAML schema validation of dsl-mappings.yaml |
 | `dsl-mappings-target-validity` | values_mapping targets exist |

--- a/library-chart/tests/cnpg-operator-bundled/run.sh
+++ b/library-chart/tests/cnpg-operator-bundled/run.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# cnpg-operator-bundled — guard the helm-install-from-flat-export path.
+#
+# When a project enables a cnpg service and runs `rda export --flat`
+# followed by vanilla `helm install`, the resulting chart must carry
+# the CloudNativePG operator + its CRDs as a sub-chart. Without that,
+# `helm install` fails with:
+#   no matches for kind "Cluster" in version "postgresql.cnpg.io/v1"
+# because nothing else installs the operator (Tilt's extension does
+# this out-of-band, but `helm install` has no such helper).
+#
+# This test locks in three invariants:
+#   1. library-chart/Chart.yaml declares `cloudnative-pg` as a conditional
+#      sub-chart dependency, gated on `cloudnative-pg.enabled`.
+#   2. dsl-mappings.yaml's cnpg chart_defaults sets
+#      `cloudnative-pg.enabled: true` so adding a cnpg service flips
+#      the operator on automatically.
+#   3. Both stay true after `chart-source.py --mode community` (the
+#      operator dep MUST NOT be stripped — it's served from the
+#      cnpg community repo, not AppCo OCI).
+#   4. `helm template` of a project with cnpg enabled renders the
+#      Cluster CR AND the operator Deployment AND the Cluster CRD.
+#      Helm 3's kind-ordering then guarantees CRDs are applied before
+#      the Cluster CR at install time.
+#
+# Skips silently when `helm` is not on PATH (matches the convention
+# used by helm-template-smoke and cnpg-image-source-switch).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+python3 - "$LIB" <<'PY'
+import os, sys, yaml
+
+lib_dir = sys.argv[1]
+
+# Invariant 1: Chart.yaml declares cloudnative-pg as conditional dep.
+with open(os.path.join(lib_dir, "Chart.yaml")) as f:
+    chart = yaml.safe_load(f)
+
+cnpg_dep = next(
+    (d for d in chart.get("dependencies", []) if d.get("name") == "cloudnative-pg"),
+    None,
+)
+if cnpg_dep is None:
+    sys.stderr.write(
+        "ERROR: library-chart/Chart.yaml is missing the `cloudnative-pg` "
+        "sub-chart dependency. Without it, `rda export --flat` + "
+        "`helm install` fails with `no matches for kind Cluster` because "
+        "nothing installs the CNPG operator + CRDs.\n"
+    )
+    sys.exit(1)
+
+if cnpg_dep.get("condition") != "cloudnative-pg.enabled":
+    sys.stderr.write(
+        f"ERROR: cloudnative-pg dep must be conditional on "
+        f"`cloudnative-pg.enabled`, got "
+        f"{cnpg_dep.get('condition')!r}. dsl-mappings flips this flag "
+        f"via chart_defaults when a cnpg service is added.\n"
+    )
+    sys.exit(1)
+
+# Invariant 2: cnpg chart_defaults enables the operator.
+with open(os.path.join(lib_dir, "dsl-mappings.yaml")) as f:
+    doc = yaml.safe_load(f)
+
+cnpg = doc.get("charts", {}).get("cnpg", {})
+versions = cnpg.get("versions", [])
+if not versions:
+    sys.stderr.write("ERROR: dsl-mappings.yaml charts.cnpg has no versions[]\n")
+    sys.exit(1)
+
+defaults = versions[0].get("chart_defaults", {}) or {}
+if defaults.get("cloudnative-pg.enabled") is not True:
+    sys.stderr.write(
+        "ERROR: dsl-mappings.yaml charts.cnpg.versions[0].chart_defaults "
+        "must set `cloudnative-pg.enabled: true` so adding a cnpg service "
+        "auto-installs the operator. Without it, `helm install` will fail "
+        "with `no matches for kind Cluster`.\n"
+    )
+    sys.exit(1)
+
+print("  ✓ Chart.yaml declares cloudnative-pg sub-chart dep")
+print("  ✓ dsl-mappings.yaml cnpg.chart_defaults enables the operator")
+PY
+
+# Invariant 3: community-mode toggle preserves the cnpg dep.
+TMP_CHART="$(mktemp -t cnpg-community-XXXXXX.yaml)"
+cp "$LIB/Chart.yaml" "$TMP_CHART"
+trap 'rm -f "$TMP_CHART"' EXIT
+
+# Run chart-source.py against a copy so we don't touch the live file.
+COMMUNITY_OUT="$(python3 "$LIB/scripts/chart-source.py" --mode community --chart "$TMP_CHART" 2>&1)"
+if ! grep -q "cloudnative-pg" "$TMP_CHART"; then
+  echo "ERROR: chart-source.py --mode community stripped the cloudnative-pg dep"
+  echo "       (it should only strip oci://dp.apps.rancher.io entries)"
+  echo "Output was: $COMMUNITY_OUT"
+  exit 1
+fi
+echo "  ✓ chart-source.py --mode community preserves cloudnative-pg dep"
+
+# Invariant 4: helm template renders operator + CRDs + Cluster CR.
+if ! command -v helm >/dev/null 2>&1; then
+  echo "  SKIP: helm not on PATH, skipping render check"
+  echo "✓ cnpg-operator-bundled: static checks passed"
+  exit 0
+fi
+
+WORK="$(mktemp -d -t cnpg-bundled.XXXXXX)"
+trap 'rm -rf "$WORK"; rm -f "$TMP_CHART"' EXIT
+
+mkdir -p "$WORK/deploy/templates" "$WORK/deploy/charts"
+ln -s "$LIB" "$WORK/deploy/charts/suse-library"
+touch "$WORK/deploy/templates/.gitkeep"
+cat > "$WORK/deploy/Chart.yaml" <<EOF
+apiVersion: v2
+name: test
+version: 0.1.0
+type: application
+dependencies:
+  - name: suse-library
+    version: "*"
+    repository: file://charts/suse-library
+EOF
+
+cat > "$WORK/deploy/values.yaml" <<'EOF'
+suse-library:
+  name: test
+  domain: localtest.me
+  services:
+    - binding: db
+      type: cnpg
+      enabled: true
+      auth:
+        user:
+          name: app
+          password: testpass
+          database: app
+  cloudnative-pg:
+    enabled: true
+  cnpg:
+    enabled: true
+    cluster:
+      instances: 1
+      storage:
+        size: 1Gi
+      bootstrap:
+        initdb:
+          database: app
+          owner: app
+EOF
+
+RENDERED="$(helm template test "$WORK/deploy" -f "$WORK/deploy/values.yaml" 2>&1)"
+
+check_kind () {
+  local label="$1" pattern="$2"
+  local count
+  count=$(echo "$RENDERED" | grep -cE "$pattern" || true)
+  if [ "$count" -gt 0 ]; then
+    echo "  ✓ $label ($count match(es))"
+  else
+    echo "  ✗ $label: missing from helm template output"
+    echo "    pattern: $pattern"
+    return 1
+  fi
+}
+
+fail=0
+check_kind "Cluster CR rendered"            "^kind: Cluster$"                              || fail=$((fail+1))
+check_kind "Cluster CRD rendered"           "name: clusters.postgresql.cnpg.io"            || fail=$((fail+1))
+
+# Operator chart: anchor on the helm.sh/chart label which is unique to
+# the cloudnative-pg sub-chart (the workload Deployment uses a different
+# helm.sh/chart label, scoped to suse-library).
+# Avoid `set -o pipefail` SIGPIPE noise by capturing with grep -c first.
+chart_label_count=$(printf '%s\n' "$RENDERED" | grep -c "helm.sh/chart: cloudnative-pg-" || true)
+if [ "$chart_label_count" -gt 0 ]; then
+  echo "  ✓ operator chart resources rendered ($chart_label_count labelled resource(s))"
+else
+  echo "  ✗ operator chart resources missing — cloudnative-pg subchart didn't render"
+  fail=$((fail+1))
+fi
+
+if [ "$fail" -gt 0 ]; then
+  echo
+  echo "FAIL: cnpg-operator-bundled detected $fail missing piece(s)."
+  echo 'This means "rda export --flat" + "helm install" will hit'
+  echo '  no matches for kind "Cluster" in version "postgresql.cnpg.io/v1"'
+  echo "because the operator + CRDs aren't being bundled."
+  exit 1
+fi
+
+echo "✓ cnpg-operator-bundled: operator + CRDs + Cluster CR all bundled"


### PR DESCRIPTION
## Summary

Adds `tests/cnpg-operator-bundled/run.sh` — a regression guard for the
`rda export --flat` + `helm install` path.

Without the cloudnative-pg sub-chart, plain `helm install` fails with
`no matches for kind Cluster in version postgresql.cnpg.io/v1` because
nothing installs the operator + CRDs (the Tilt extension does this
out-of-band, but `helm install` has no equivalent helper).

The fix is already in place across `Chart.yaml` + `dsl-mappings.yaml`:
- `Chart.yaml` declares `cloudnative-pg` as a conditional sub-chart dep
- `dsl-mappings.yaml` `cnpg.chart_defaults` flips `cloudnative-pg.enabled: true`
- `chart-source.py` preserves the dep in both `appco` and `community`
  mode (the CNPG operator chart is served from the community helm repo
  regardless)

This test locks all four invariants in:

1. `Chart.yaml` declares the dep, gated on `cloudnative-pg.enabled`
2. `dsl-mappings.yaml` `cnpg.versions[0].chart_defaults` enables the operator
3. `chart-source.py --mode community` keeps the dep (it only strips `oci://dp.apps.rancher.io` entries)
4. `helm template` of a cnpg-enabled project renders the Cluster CR
   AND the Cluster CRD AND the operator chart's resources. Helm 3's
   kind-ordering then guarantees CRDs land before the Cluster CR at
   install time.

The test skips the helm-render check when `helm` isn't on PATH (matches
the convention of `helm-template-smoke` and `cnpg-image-source-switch`).

## Test plan
- [x] `bash library-chart/tests/cnpg-operator-bundled/run.sh` passes
- [x] Test fails when `cloudnative-pg` is removed from `Chart.yaml`
- [x] Test fails when `cloudnative-pg.enabled: true` is removed from `cnpg.chart_defaults`
- [x] All sibling tests (`cnpg-image-source-switch`, `cnpg-initdb-secret`, `chart-source-overlay-sync`, `dep-defaults-presence`, `helm-template-smoke`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)